### PR TITLE
[Feat] Account UI 구현

### DIFF
--- a/mirror-soul/app/index.tsx
+++ b/mirror-soul/app/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Platform, SafeAreaView, StatusBar, StyleSheet, View } from 'react-native';
+import { router } from 'expo-router';
 
 import ActionCard from '@/src/components/common/ActionCard';
 import HomeBackground from '@/src/components/home/HomeBackground';
@@ -27,7 +28,7 @@ export default function Home() {
           <ActionCard
             title="Create a New Mirror"
             description="Start the journey to find your soul's reflection"
-            onPress={() => console.log('Create a New Mirror clicked')}
+            onPress={() => router.push('/signup/Account')}
           />
           <ActionCard
             title="Awaken My Mirror"

--- a/mirror-soul/app/signup/Account.tsx
+++ b/mirror-soul/app/signup/Account.tsx
@@ -1,0 +1,127 @@
+import SecurityFooter from '@/src/components/home/SecurityFooter';
+import SignupBackground from '@/src/components/signup/Account/SignupBackground';
+import SignupHeader from '@/src/components/signup/Account/SignupHeader';
+import TermsCheckbox from '@/src/components/signup/Account/TermsCheckbox';
+import CustomInput from '@/src/components/signup/common/CustomInput';
+import PrimaryButton from '@/src/components/signup/common/PrimaryButton';
+import { Colors } from '@/src/constants/theme';
+import React, { useState } from 'react';
+import { KeyboardAvoidingView, Platform, SafeAreaView, ScrollView, StatusBar, StyleSheet, View } from 'react-native';
+
+export default function AccountScreen() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [agreed, setAgreed] = useState(false);
+
+  // 모든 폼이 입력되었는지 검사하여 버튼 활성화 여부 결정
+  const isFormValid = name.trim().length > 0 && email.trim().length > 0 && password.length >= 8 && agreed;
+
+  const handleContinue = () => {
+    if (isFormValid) {
+      console.log('Proceed to next step');
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar barStyle="light-content" backgroundColor="#000" />
+      <SignupBackground />
+
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={styles.keyboardView}
+      >
+        <ScrollView
+          contentContainerStyle={styles.scrollContainer}
+          showsVerticalScrollIndicator={false}
+        >
+          {/* Main Content Container */}
+          <View style={styles.container}>
+            <SignupHeader />
+
+            {/* Form Body */}
+            <View style={styles.formContainer}>
+              <CustomInput
+                label="Your Name"
+                placeholder="How should we call you?"
+                value={name}
+                onChangeText={setName}
+              />
+              <CustomInput
+                label="email"
+                placeholder="your@email.com"
+                keyboardType="email-address"
+                autoCapitalize="none"
+                value={email}
+                onChangeText={setEmail}
+              />
+              <CustomInput
+                label="password"
+                placeholder="At least 8 characters"
+                secureTextEntry
+                value={password}
+                onChangeText={setPassword}
+              />
+
+              <TermsCheckbox
+                checked={agreed}
+                onToggle={() => setAgreed(!agreed)}
+              />
+
+              {/* Submit Button */}
+              <View style={styles.buttonWrapper}>
+                <PrimaryButton
+                  title="Continue"
+                  disabled={!isFormValid}
+                  onPress={handleContinue}
+                />
+              </View>
+            </View>
+
+            {/* Footer */}
+            <View style={styles.footerContainer}>
+              <SecurityFooter />
+            </View>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: Colors.primary.soulBlack,
+    paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0,
+  },
+  keyboardView: {
+    flex: 1,
+    zIndex: 1,
+  },
+  scrollContainer: {
+    flexGrow: 1,
+    alignItems: 'center',
+    paddingVertical: 50, // Top margin padding
+  },
+  container: {
+    width: '100%',
+    maxWidth: 345, // Figma layout width matching
+    alignItems: 'center',
+  },
+  formContainer: {
+    width: '100%',
+    gap: 24,
+    marginTop: 40,
+  },
+  buttonWrapper: {
+    marginTop: 8,
+    width: '100%',
+  },
+  footerContainer: {
+    marginTop: 40,
+    width: '100%',
+    alignItems: 'center',
+  }
+});

--- a/mirror-soul/assets/images/common/Continue_icon.svg
+++ b/mirror-soul/assets/images/common/Continue_icon.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.16591 9.99829H15.8305" stroke="#4A5565" stroke-width="1.66636" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9.99818 4.16602L15.8305 9.99829L9.99818 15.8306" stroke="#4A5565" stroke-width="1.66636" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/mirror-soul/src/components/signup/Account/SignupBackground.tsx
+++ b/mirror-soul/src/components/signup/Account/SignupBackground.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import Svg, { Defs, RadialGradient, Rect, Stop } from 'react-native-svg';
+import { Colors } from '@/src/constants/theme';
+
+/**
+ * 회원가입 화면 전용 방사형 그라디언트 컴포넌트
+ */
+export default function SignupBackground() {
+  return (
+    <View style={StyleSheet.absoluteFill}>
+      <View style={[StyleSheet.absoluteFill, { backgroundColor: Colors.primary.soulBlack }]} />
+      <Svg height="100%" width="100%" style={StyleSheet.absoluteFill}>
+        <Defs>
+          <RadialGradient
+            id="grad1"
+            cx="67.07%"
+            cy="50%"
+            rx="60%"
+            ry="60%"
+            fx="67.07%"
+            fy="50%"
+          >
+            <Stop offset="0" stopColor={Colors.glass.purple08} stopOpacity="1" />
+            <Stop offset="0.6" stopColor={Colors.primary.soulBlack} stopOpacity="0" />
+          </RadialGradient>
+        </Defs>
+        <Rect x="0" y="0" width="100%" height="100%" fill="url(#grad1)" />
+      </Svg>
+    </View>
+  );
+}

--- a/mirror-soul/src/components/signup/Account/SignupHeader.tsx
+++ b/mirror-soul/src/components/signup/Account/SignupHeader.tsx
@@ -1,0 +1,38 @@
+import { Colors } from '@/src/constants/theme';
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+/**
+ * 회원가입 헤더 (타이틀 및 부제)
+ */
+export default function SignupHeader() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Create Your Account</Text>
+      <Text style={styles.subtitle}>Just the essentials. We'll gather more as we go.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    alignItems: 'flex-start',
+    gap: 8,
+    marginTop: 40,
+  },
+  title: {
+    color: Colors.neutral.pureWhite,
+    fontSize: 30,
+    fontWeight: '500',
+    lineHeight: 36,
+    letterSpacing: 0.396,
+  },
+  subtitle: {
+    color: Colors.neutral.lightGray,
+    fontSize: 14,
+    fontWeight: '400',
+    lineHeight: 20,
+    letterSpacing: -0.15,
+  }
+});

--- a/mirror-soul/src/components/signup/Account/TermsCheckbox.tsx
+++ b/mirror-soul/src/components/signup/Account/TermsCheckbox.tsx
@@ -1,0 +1,92 @@
+import { Colors } from '@/src/constants/theme';
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+
+interface TermsCheckboxProps {
+  checked: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * 이용약관 동의 체크박스 컴포넌트
+ */
+export default function TermsCheckbox({ checked, onToggle }: TermsCheckboxProps) {
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        activeOpacity={0.8}
+        onPress={onToggle}
+        style={[styles.checkbox, checked && styles.checkboxActive]}
+      >
+        {checked && <View style={styles.checkInner} />}
+      </TouchableOpacity>
+
+      <View style={styles.textContainer}>
+        <Text style={styles.baseText}>
+          <Text style={styles.link1} onPress={() => console.log('Terms clicked')}>서비스 이용약관</Text>
+          <Text style={styles.baseText}> 및 </Text>
+          <Text style={styles.link2} onPress={() => console.log('Privacy clicked')}>개인정보 처리방침</Text>
+          <Text style={styles.baseText}>에 동의합니다.</Text>
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    paddingHorizontal: 16.6,
+    paddingTop: 16.6,
+    paddingBottom: 16.6, // Adjusted slightly from 0.612 to be vertically balanced
+    borderRadius: 16,
+    borderWidth: 0.6,
+    borderColor: Colors.glass.white10,
+    backgroundColor: Colors.glass.white5,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 16,
+  },
+  checkbox: {
+    width: 20,
+    height: 20,
+    borderRadius: 4,
+    borderWidth: 1.8,
+    borderColor: Colors.glass.white30,
+    backgroundColor: Colors.glass.white5,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  checkboxActive: {
+    backgroundColor: Colors.primary.electricCyan,
+    borderColor: Colors.primary.electricCyan,
+  },
+  checkInner: {
+    width: 10,
+    height: 10,
+    backgroundColor: Colors.primary.soulBlack,
+    borderRadius: 2,
+  },
+  textContainer: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  baseText: {
+    color: Colors.neutral.lightGrayText,
+    fontSize: 14,
+    fontWeight: '400',
+    lineHeight: 19.5,
+  },
+  link1: {
+    color: Colors.primary.electricCyan,
+    fontSize: 15,
+    fontWeight: '500',
+    textDecorationLine: 'underline',
+  },
+  link2: {
+    color: Colors.primary.vividPurple,
+    fontSize: 15,
+    fontWeight: '500',
+    textDecorationLine: 'underline',
+  }
+});

--- a/mirror-soul/src/components/signup/common/CustomInput.tsx
+++ b/mirror-soul/src/components/signup/common/CustomInput.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { View, Text, TextInput, StyleSheet, TextInputProps, ViewStyle } from 'react-native';
+import { Colors } from '@/src/constants/theme';
+
+interface CustomInputProps extends TextInputProps {
+  label: string;
+  containerStyle?: ViewStyle;
+}
+
+/**
+ * 공통 재사용 입력 폼 컴포넌트 (라벨 + 텍스트 인풋)
+ */
+export default function CustomInput({ label, containerStyle, style, ...props }: CustomInputProps) {
+  return (
+    <View style={[styles.container, containerStyle]}>
+      <Text style={styles.label}>{label}</Text>
+      <TextInput 
+        style={[styles.input, style]}
+        placeholderTextColor={Colors.neutral.darkGray}
+        {...props}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    gap: 8,
+  },
+  label: {
+    color: Colors.neutral.lightGray,
+    fontSize: 14,
+    fontWeight: '500',
+    lineHeight: 20,
+    letterSpacing: -0.15,
+  },
+  input: {
+    width: '100%',
+    height: 49,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderRadius: 16,
+    borderWidth: 0.6,
+    borderColor: Colors.glass.white10,
+    backgroundColor: Colors.glass.white5,
+    color: Colors.neutral.pureWhite,
+    fontSize: 16,
+    fontWeight: '400',
+    letterSpacing: -0.312,
+  }
+});

--- a/mirror-soul/src/components/signup/common/PrimaryButton.tsx
+++ b/mirror-soul/src/components/signup/common/PrimaryButton.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { Text, TouchableOpacity, StyleSheet, ViewStyle } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Colors } from '@/src/constants/theme';
+import ContinueIcon from '@/assets/images/common/Continue_icon.svg';
+
+interface PrimaryButtonProps {
+  title: string;
+  onPress: () => void;
+  disabled?: boolean;
+  style?: ViewStyle;
+}
+
+/**
+ * 공용 하단 플로팅/스탠다드 Primary Button 컴포넌트
+ */
+export default function PrimaryButton({ title, onPress, disabled, style }: PrimaryButtonProps) {
+  return (
+    <TouchableOpacity 
+      activeOpacity={0.8}
+      onPress={onPress}
+      disabled={disabled}
+      style={[
+        styles.button, 
+        disabled ? styles.buttonDisabled : undefined,
+        style
+      ]}
+    >
+      {!disabled && (
+        <LinearGradient
+          colors={Colors.gradient.cyanToPurple}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 0 }}
+          style={[StyleSheet.absoluteFill, { borderRadius: 16 }]}
+        />
+      )}
+      <Text style={[styles.title, disabled ? styles.titleDisabled : styles.titleActive]}>
+        {title}
+      </Text>
+      {/* SVG Icon typically manages its own fill, but we can render it safely. */}
+      {/* If it doesn't inherit props, we just render it. */}
+      <ContinueIcon width={24} height={24} />
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    width: '100%',
+    height: 56,
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: 8,
+    borderRadius: 16,
+    overflow: 'hidden', // background gradient bleeding cutoff
+  },
+  buttonDisabled: {
+    backgroundColor: Colors.glass.white5,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '500',
+    lineHeight: 24,
+    letterSpacing: -0.312,
+    zIndex: 1, // ensures text stays above absolute linear gradient
+  },
+  titleDisabled: {
+    color: Colors.neutral.disabledText,
+  },
+  titleActive: {
+    color: Colors.primary.soulBlack,
+  }
+});

--- a/mirror-soul/src/constants/theme.ts
+++ b/mirror-soul/src/constants/theme.ts
@@ -13,11 +13,15 @@ export const Colors = {
     pureWhite: '#FFFFFF',
     lightGray: '#99A1AF',
     darkGray: '#6A7282',
+    disabledText: '#4A5565',
+    lightGrayText: '#D1D5DC',
   },
   glass: {
     white5: 'rgba(255, 255, 255, 0.05)',
     white10: 'rgba(255, 255, 255, 0.10)',
+    white30: 'rgba(255, 255, 255, 0.30)',
     cyan18: 'rgba(0, 255, 255, 0.18)',
     purple18: 'rgba(147, 51, 234, 0.18)',
+    purple08: 'rgba(142, 85, 236, 0.08)',
   }
 };


### PR DESCRIPTION
## 💡 작업 동기 및 목적
- 초기 홈 화면에서 이어지는 '회원가입(Account)' 플로우의 엔트리 화면 및 폼(Form) UI를 구현했습니다.
- 추후 회원가입 절차가 여러 단계로 확장될 것을 고려하여 라우팅 뎁스를 `/signup/Account`로 분리하고, 화면 구성 요소를 단일 책임 원칙(SRP)에 따라 모듈화했습니다.
- `theme.ts`의 전역 디자인 상수를 엄격하게 준수하여 하드코딩 없는 독립적이고 재사용성 높은 UI 컴포넌트 환경을 구축했습니다.
- Close #7 

## 📝 변경 사항
- **라우팅 연결 및 화면 구성**
  - [x] 신규 라우터 [app/signup/Account.tsx](cci:7://file:///Users/shinwookkang/Desktop/MirrorSoul/mirror-soul/app/signup/Account.tsx:0:0-0:0) 화면 생성 및 조립
  - [x] [app/index.tsx](cci:7://file:///Users/shinwookkang/Desktop/MirrorSoul/mirror-soul/app/index.tsx:0:0-0:0)의 "Create a New Mirror" 버튼 클릭 시 `/signup/Account`로 이동하도록 연동
- **회원가입 도메인 전용 컴포넌트 구현 (`src/components/signup/Account/`)**
  - [x] `SignupBackground.tsx`: 회원가입 화면 전용 방사형 보라색 그라디언트 배경 구현
  - [x] `SignupHeader.tsx`: 타이틀 및 서브 타이틀 렌더링
  - [x] `TermsCheckbox.tsx`: 서비스 이용약관 및 개인정보 처리방침 동의 체크박스 구현 (텍스트 및 아이콘 1:1 수직 중앙 정렬 적용)
- **공용 UI 컴포넌트 구현 (`src/components/signup/common/`)**
  - [x] `CustomInput.tsx`: 이름, 이메일, 패스워드를 위한 공용 라벨+인풋 폼 컴포넌트 구현
  - [x] `PrimaryButton.tsx`: 하단 공통 활성화/비활성화 버튼 구현 (입력 조건 충족에 따른 `LinearGradient` 활성화 로직 적용)
- **전역 테마 상수 (`theme.ts`) 확장**
  - [x] Signup 화면에 사용되는 텍스트(`lightGrayText`, `disabledText`) 및 `purple08` 그라디언트 컬러 상수 추가

## 📸 스크린샷 (선택)
<img width="585" height="1266" alt="Account_UI" src="https://github.com/user-attachments/assets/bf9b1883-f672-439e-82c6-99a0217b48ba" />


## 🧐 리뷰 포인트 / 기타 특이사항
- 모든 인풋(이름, 이메일, 패스워드 최소 8자)과 약관 동의(체크박스)가 완료되어야만 `Continue` 버튼이 활성화되도록 기본 폼 Validation 로직을 적용해 두었습니다. 실제 백엔드 연동(API 콜) 및 다음 Auth 스텝으로 넘어가는 부분은 추후 작업 예정입니다.
