### PR TITLE
feat: Call history Detail UI 구현

### DIFF
--- a/mirror-soul/app/_layout.tsx
+++ b/mirror-soul/app/_layout.tsx
@@ -7,6 +7,7 @@ export default function RootLayout() {
     <>
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="index" />
+        <Stack.Screen name="call-detail" />
       </Stack>
       <StatusBar style="light" />
     </>

--- a/mirror-soul/app/call-detail.tsx
+++ b/mirror-soul/app/call-detail.tsx
@@ -1,0 +1,62 @@
+import CallDetailAlert from '@/src/components/home/history/detail/CallDetailAlert';
+import CallDetailBody from '@/src/components/home/history/detail/CallDetailBody';
+import CallDetailFooter from '@/src/components/home/history/detail/CallDetailFooter';
+import CallDetailHeader from '@/src/components/home/history/detail/CallDetailHeader';
+import { Colors } from '@/src/constants/theme';
+import { MOCK_CALL_HISTORY } from '@/src/mocks/historyMocks';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import React from 'react';
+import { StyleSheet, View, Text } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+/**
+ * 통화 기록 상세 화면 (루트 스택 레벨)
+ * HistoryCallCard 탭 시 진입하며, BottomNavbar 없이 풀스크린으로 표시됩니다.
+ */
+export default function CallDetailScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { id } = useLocalSearchParams<{ id: string }>();
+
+  // id로 통화 데이터 조회 (API 연동 시 useQuery 등으로 교체)
+  const callItem = MOCK_CALL_HISTORY.find((item) => item.id === id);
+
+  if (!callItem) {
+    return (
+      <View style={[styles.container, { paddingTop: insets.top }]}>
+        <Text style={styles.errorText}>통화 기록을 찾을 수 없습니다.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top }]}>
+      <CallDetailHeader
+        name={callItem.name}
+        age={callItem.age}
+        callSequenceNumber={callItem.callSequenceNumber}
+        consistencyPercent={callItem.consistencyPercent}
+        onBack={() => router.back()}
+      />
+      <CallDetailAlert />
+      <CallDetailBody initialMessages={callItem.messages} />
+      <View style={{ paddingBottom: insets.bottom }}>
+        <CallDetailFooter />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.primary.soulBlack,
+  },
+  errorText: {
+    color: Colors.neutral.lightGray,
+    textAlign: 'center',
+    marginTop: 40,
+    fontFamily: 'Inter',
+    fontSize: 14,
+  },
+});

--- a/mirror-soul/src/components/home/history/HistoryList.tsx
+++ b/mirror-soul/src/components/home/history/HistoryList.tsx
@@ -1,43 +1,17 @@
+import { MOCK_CALL_HISTORY } from '@/src/mocks/historyMocks';
+import { useRouter } from 'expo-router';
 import React from 'react';
 import { FlatList, StyleSheet, View } from 'react-native';
 import { HistoryFilterType } from './HistoryFilterRow';
-import HistoryCallCard, { HistoryCallItemData } from './parts/HistoryCallCard';
-
-// 임시 목업 데이터
-const MOCK_CALL_HISTORY: HistoryCallItemData[] = [
-  {
-    id: '1',
-    name: '수빈',
-    age: 28,
-    consistencyPercent: 94,
-    dateStr: '오늘',
-    timeStr: '14:30',
-    direction: 'SENT',
-    callTypeDesc: '내가 시작한 통화',
-    durationLabel: '8분 23초',
-    twinMatchLabel: '상대 Twin 92%',
-    tags: ['음악', '전시회', '크리에이티브'],
-  },
-  {
-    id: '2',
-    name: '지우',
-    age: 26,
-    consistencyPercent: 88,
-    dateStr: '어제',
-    timeStr: '21:15',
-    direction: 'RECEIVED',
-    callTypeDesc: '상대방이 시작한 통화',
-    durationLabel: '12분 40초',
-    twinMatchLabel: '상대 Twin 85%',
-    tags: ['여행', '맛집'],
-  },
-];
+import HistoryCallCard from './parts/HistoryCallCard';
 
 interface HistoryListProps {
   filter: HistoryFilterType;
 }
 
 export default function HistoryList({ filter }: HistoryListProps) {
+  const router = useRouter();
+
   // 필터링 로직: 표시 문자열이 아닌 도메인 데이터(direction)를 기준으로 판정
   const data = MOCK_CALL_HISTORY.filter((item) => {
     if (filter === 'ALL') return true;
@@ -49,7 +23,14 @@ export default function HistoryList({ filter }: HistoryListProps) {
       <FlatList
         data={data}
         keyExtractor={(item) => item.id}
-        renderItem={({ item }) => <HistoryCallCard data={item} />}
+        renderItem={({ item }) => (
+          <HistoryCallCard
+            data={item}
+            onPress={() =>
+              router.push({ pathname: '/call-detail', params: { id: item.id } })
+            }
+          />
+        )}
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
         scrollEnabled={false} // 부모 ScrollView에 의해 스크롤됨

--- a/mirror-soul/src/components/home/history/detail/CallDetailAlert.tsx
+++ b/mirror-soul/src/components/home/history/detail/CallDetailAlert.tsx
@@ -27,14 +27,14 @@ const styles = StyleSheet.create({
   container: {
     paddingHorizontal: 12,
     paddingTop: 12,
-    paddingBottom: 1,
+    paddingBottom: 12,
     borderBottomWidth: 0.612,
     borderBottomColor: Colors.glass.purple20,
     backgroundColor: Colors.glass.purple10,
   },
   row: {
     flexDirection: 'row',
-    alignItems: 'flex-start',
+    alignItems: 'center',
     gap: 8,
     alignSelf: 'stretch',
   },

--- a/mirror-soul/src/components/home/history/detail/CallDetailAlert.tsx
+++ b/mirror-soul/src/components/home/history/detail/CallDetailAlert.tsx
@@ -1,0 +1,54 @@
+import EditPencilIcon from '@/assets/images/common/history/call_history/call_edit_pencil.svg';
+import PurpleInfoIcon from '@/assets/images/common/history/call_history/puple_info.svg';
+import { Colors } from '@/src/constants/theme';
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+/**
+ * 통화 상세 상단 알림 배너 (SRP)
+ * 편집 기능 안내 문구를 자주색 글래스 배너로 표시합니다.
+ */
+export default function CallDetailAlert() {
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        <PurpleInfoIcon width={16} height={16} />
+        <View style={styles.paragraph}>
+          <Text style={styles.text}>우측 상단의 </Text>
+          <EditPencilIcon width={12} height={12} />
+          <Text style={styles.text}> 아이콘을 탭하여 내 Twin의 답변을 수정할 수 있습니다</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 12,
+    paddingTop: 12,
+    paddingBottom: 1,
+    borderBottomWidth: 0.612,
+    borderBottomColor: Colors.glass.purple20,
+    backgroundColor: Colors.glass.purple10,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: 8,
+    alignSelf: 'stretch',
+  },
+  paragraph: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  },
+  text: {
+    color: Colors.neutral.lavender,
+    fontFamily: 'Inter',
+    fontSize: 12,
+    fontWeight: '400',
+    lineHeight: 16,
+  },
+});

--- a/mirror-soul/src/components/home/history/detail/CallDetailBody.tsx
+++ b/mirror-soul/src/components/home/history/detail/CallDetailBody.tsx
@@ -1,0 +1,73 @@
+import { ChatMessage } from '@/src/components/home/history/parts/HistoryCallCard';
+import React, { useState } from 'react';
+import { ScrollView, StyleSheet, View } from 'react-native';
+import ChatBubble from './parts/ChatBubble';
+
+interface CallDetailBodyProps {
+  initialMessages: ChatMessage[];
+}
+
+/**
+ * 통화 메시지 목록 및 편집 상태 관리 (SRP)
+ * 메시지 렌더링과 편집 상태를 이 컴포넌트에서 중앙 관리합니다.
+ */
+export default function CallDetailBody({ initialMessages }: CallDetailBodyProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>(initialMessages);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editText, setEditText] = useState('');
+
+  const handleEditStart = (id: string, currentText: string) => {
+    setEditingId(id);
+    setEditText(currentText);
+  };
+
+  const handleEditSave = (id: string) => {
+    setMessages((prev) =>
+      prev.map((msg) =>
+        msg.id === id
+          ? { ...msg, text: editText.trim() || msg.text, isEdited: true }
+          : msg
+      )
+    );
+    setEditingId(null);
+  };
+
+  const handleEditCancel = () => {
+    setEditingId(null);
+  };
+
+  return (
+    <ScrollView
+      style={styles.scrollView}
+      contentContainerStyle={styles.content}
+      showsVerticalScrollIndicator={false}
+    >
+      {messages.map((msg) => (
+        <View key={msg.id} style={styles.bubbleWrapper}>
+          <ChatBubble
+            message={msg}
+            editingId={editingId}
+            editText={editText}
+            onEditStart={handleEditStart}
+            onEditSave={handleEditSave}
+            onEditCancel={handleEditCancel}
+            onEditTextChange={setEditText}
+          />
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollView: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+    gap: 16,
+  },
+  bubbleWrapper: {
+    alignSelf: 'stretch',
+  },
+});

--- a/mirror-soul/src/components/home/history/detail/CallDetailFooter.tsx
+++ b/mirror-soul/src/components/home/history/detail/CallDetailFooter.tsx
@@ -1,0 +1,43 @@
+import { Colors } from '@/src/constants/theme';
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+/**
+ * 통화 상세 하단 푸터 (SRP)
+ * Twin 학습 안내 문구를 표시합니다.
+ */
+export default function CallDetailFooter() {
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        <Text style={styles.text}>수정된 답변은 Twin의 학습에 반영됩니다</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 1,
+    borderTopWidth: 0.612,
+    borderTopColor: Colors.glass.white10,
+    backgroundColor: Colors.glass.black40,
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 8,
+    alignSelf: 'stretch',
+  },
+  text: {
+    color: Colors.neutral.lightGray,
+    fontFamily: 'Inter',
+    fontSize: 12,
+    fontWeight: '400',
+    lineHeight: 16,
+    textAlign: 'center',
+  },
+});

--- a/mirror-soul/src/components/home/history/detail/CallDetailFooter.tsx
+++ b/mirror-soul/src/components/home/history/detail/CallDetailFooter.tsx
@@ -20,7 +20,7 @@ const styles = StyleSheet.create({
   container: {
     paddingHorizontal: 16,
     paddingTop: 16,
-    paddingBottom: 1,
+    paddingBottom: 16,
     borderTopWidth: 0.612,
     borderTopColor: Colors.glass.white10,
     backgroundColor: Colors.glass.black40,

--- a/mirror-soul/src/components/home/history/detail/CallDetailHeader.tsx
+++ b/mirror-soul/src/components/home/history/detail/CallDetailHeader.tsx
@@ -72,7 +72,7 @@ const styles = StyleSheet.create({
   container: {
     paddingHorizontal: 16,
     paddingTop: 16,
-    paddingBottom: 1,
+    paddingBottom: 16,
     borderBottomWidth: 0.612,
     borderBottomColor: Colors.glass.white10,
     backgroundColor: Colors.glass.black40,

--- a/mirror-soul/src/components/home/history/detail/CallDetailHeader.tsx
+++ b/mirror-soul/src/components/home/history/detail/CallDetailHeader.tsx
@@ -1,0 +1,128 @@
+import RightNarrowIcon from '@/assets/images/common/Right_narrow.svg';
+import { Colors, Radii } from '@/src/constants/theme';
+import { LinearGradient } from 'expo-linear-gradient';
+import React from 'react';
+import {
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+
+interface CallDetailHeaderProps {
+  name: string;
+  age: number;
+  callSequenceNumber: number;
+  consistencyPercent: number;
+  onBack: () => void;
+}
+
+/**
+ * 통화 상세 헤더 (SRP)
+ * 뒤로가기 버튼, 이름/나이/부제목, 일치도 배지를 렌더링합니다.
+ */
+export default function CallDetailHeader({
+  name,
+  age,
+  callSequenceNumber,
+  consistencyPercent,
+  onBack,
+}: CallDetailHeaderProps) {
+  return (
+    <View style={styles.container}>
+      <View style={styles.row}>
+        {/* 뒤로가기 */}
+        <TouchableOpacity
+          onPress={onBack}
+          style={styles.backButton}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel="뒤로가기"
+        >
+          <RightNarrowIcon
+            width={20}
+            height={20}
+            style={{ transform: [{ rotate: '180deg' }] }}
+          />
+        </TouchableOpacity>
+
+        {/* 이름 + 부제목 */}
+        <View style={styles.content}>
+          <Text style={styles.title}>{name}, {age}</Text>
+          <Text style={styles.subtitle}>
+            {name}님과의 {callSequenceNumber}번 째 대화 내용
+          </Text>
+        </View>
+
+        {/* 일치도 배지 */}
+        <LinearGradient
+          colors={[Colors.glass.cyan20, Colors.glass.purple20]}
+          start={{ x: 0, y: 0.5 }}
+          end={{ x: 1, y: 0.5 }}
+          style={styles.badge}
+        >
+          <Text style={styles.badgeText}>{consistencyPercent}%</Text>
+        </LinearGradient>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 1,
+    borderBottomWidth: 0.612,
+    borderBottomColor: Colors.glass.white10,
+    backgroundColor: Colors.glass.black40,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    alignSelf: 'stretch',
+    height: 52,
+  },
+  backButton: {
+    width: 32,
+    height: 32,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  content: {
+    flex: 1,
+    flexDirection: 'column',
+  },
+  title: {
+    color: Colors.neutral.pureWhite,
+    fontFamily: 'Inter',
+    fontSize: 24,
+    fontWeight: '500',
+    lineHeight: 36,
+    letterSpacing: 0.07,
+  },
+  subtitle: {
+    color: Colors.neutral.lightGray,
+    fontFamily: 'Inter',
+    fontSize: 12,
+    fontWeight: '400',
+    lineHeight: 16,
+  },
+  badge: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: Radii.full,
+    borderWidth: 0.612,
+    borderColor: 'rgba(0, 211, 243, 0.30)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  badgeText: {
+    color: Colors.primary.electricCyan,
+    fontFamily: 'Inter',
+    fontSize: 12,
+    fontWeight: '400',
+    lineHeight: 16,
+  },
+});

--- a/mirror-soul/src/components/home/history/detail/parts/ChatBubble.tsx
+++ b/mirror-soul/src/components/home/history/detail/parts/ChatBubble.tsx
@@ -89,6 +89,9 @@ export default function ChatBubble({
             style={styles.editButtonAbsolute}
             onPress={() => onEditStart(message.id, message.text)}
             activeOpacity={0.8}
+            accessibilityRole="button"
+            accessibilityLabel="메시지 수정"
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
           >
             <EditPencilIcon width={12} height={12} />
           </TouchableOpacity>

--- a/mirror-soul/src/components/home/history/detail/parts/ChatBubble.tsx
+++ b/mirror-soul/src/components/home/history/detail/parts/ChatBubble.tsx
@@ -1,0 +1,169 @@
+import EditPencilIcon from '@/assets/images/common/history/call_history/call_edit_pencil.svg';
+import { Colors, Radii } from '@/src/constants/theme';
+import { LinearGradient } from 'expo-linear-gradient';
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { ChatMessage } from '../../parts/HistoryCallCard';
+import ChatEditForm from './ChatEditForm';
+
+interface ChatBubbleProps {
+  message: ChatMessage;
+  editingId: string | null;
+  editText: string;
+  onEditStart: (id: string, currentText: string) => void;
+  onEditSave: (id: string) => void;
+  onEditCancel: () => void;
+  onEditTextChange: (text: string) => void;
+}
+
+/**
+ * 단일 채팅 말풍선 컴포넌트 (SRP)
+ * direction에 따라 상대방(RECEIVED) / 나(SENT) 스타일을 분기합니다.
+ */
+export default function ChatBubble({
+  message,
+  editingId,
+  editText,
+  onEditStart,
+  onEditSave,
+  onEditCancel,
+  onEditTextChange,
+}: ChatBubbleProps) {
+  const isSent = message.direction === 'SENT';
+  const isEditing = editingId === message.id;
+
+  // 수정 모드일 때
+  if (isEditing) {
+    return (
+      <View style={styles.rowRight}>
+        <ChatEditForm
+          value={editText}
+          onChangeText={onEditTextChange}
+          onSave={() => onEditSave(message.id)}
+          onCancel={onEditCancel}
+        />
+      </View>
+    );
+  }
+
+  // 상대방 말풍선 (RECEIVED)
+  if (!isSent) {
+    return (
+      <View style={styles.rowLeft}>
+        <View style={[styles.bubbleBase, styles.receivedBubble]}>
+          <Text style={styles.messageText}>{message.text}</Text>
+        </View>
+        <Text style={styles.timestamp}>{message.timestamp}</Text>
+      </View>
+    );
+  }
+
+  // 내 말풍선 (SENT)
+  return (
+    <View style={styles.rowRight}>
+      <LinearGradient
+        colors={[Colors.glass.purple20, Colors.glass.pink20]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={[styles.bubbleBase, styles.sentBubble]}
+      >
+        <Text style={styles.messageText}>{message.text}</Text>
+
+        {/* 편집 버튼 & 수정됨 레이블 */}
+        <View style={styles.editRow}>
+          {message.isEdited && (
+            <Text style={styles.editedLabel}>수정됨</Text>
+          )}
+          <TouchableOpacity
+            style={styles.editButton}
+            onPress={() => onEditStart(message.id, message.text)}
+            activeOpacity={0.7}
+            accessibilityLabel="메시지 수정"
+          >
+            <EditPencilIcon width={12} height={12} />
+          </TouchableOpacity>
+        </View>
+      </LinearGradient>
+      <Text style={[styles.timestamp, styles.timestampRight]}>{message.timestamp}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  rowLeft: {
+    alignSelf: 'flex-start',
+    alignItems: 'flex-start',
+    gap: 4,
+    maxWidth: '75%',
+  },
+  rowRight: {
+    alignSelf: 'flex-end',
+    alignItems: 'flex-end',
+    gap: 4,
+    maxWidth: '75%',
+  },
+  bubbleBase: {
+    paddingHorizontal: 12,
+    paddingTop: 12,
+    paddingBottom: 8,
+    borderWidth: 0.612,
+  },
+  receivedBubble: {
+    borderTopLeftRadius: Radii.bubble,   // 6 — 발신 기원 표시
+    borderTopRightRadius: Radii.lg,      // 16
+    borderBottomRightRadius: Radii.lg,
+    borderBottomLeftRadius: Radii.lg,
+    borderColor: Colors.glass.white10,
+    backgroundColor: Colors.glass.white10,
+  },
+  sentBubble: {
+    borderTopLeftRadius: Radii.lg,      // 16
+    borderTopRightRadius: Radii.bubble, // 6 — 발신 기원 표시
+    borderBottomRightRadius: Radii.lg,
+    borderBottomLeftRadius: Radii.lg,
+    borderColor: Colors.glass.purple30,
+  },
+  messageText: {
+    color: Colors.neutral.pureWhite,
+    fontFamily: 'Inter',
+    fontSize: 14,
+    fontWeight: '400',
+    lineHeight: 22,
+    letterSpacing: -0.15,
+  },
+  editRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    gap: 6,
+    marginTop: 4,
+  },
+  editedLabel: {
+    color: Colors.neutral.darkGray,
+    fontFamily: 'Inter',
+    fontSize: 12,
+    fontWeight: '400',
+    lineHeight: 16,
+  },
+  editButton: {
+    width: 24,
+    height: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: Radii.full,
+    borderWidth: 0.612,
+    borderColor: Colors.glass.purple50,
+    backgroundColor: Colors.glass.purple30,
+  },
+  timestamp: {
+    color: Colors.neutral.darkGray,
+    fontFamily: 'Inter',
+    fontSize: 12,
+    fontWeight: '400',
+    lineHeight: 16,
+    paddingHorizontal: 8,
+  },
+  timestampRight: {
+    textAlign: 'right',
+  },
+});

--- a/mirror-soul/src/components/home/history/detail/parts/ChatBubble.tsx
+++ b/mirror-soul/src/components/home/history/detail/parts/ChatBubble.tsx
@@ -2,7 +2,7 @@ import EditPencilIcon from '@/assets/images/common/history/call_history/call_edi
 import { Colors, Radii } from '@/src/constants/theme';
 import { LinearGradient } from 'expo-linear-gradient';
 import React from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View, TextInput } from 'react-native';
 import { ChatMessage } from '../../parts/HistoryCallCard';
 import ChatEditForm from './ChatEditForm';
 
@@ -18,7 +18,7 @@ interface ChatBubbleProps {
 
 /**
  * 단일 채팅 말풍선 컴포넌트 (SRP)
- * direction에 따라 상대방(RECEIVED) / 나(SENT) 스타일을 분기합니다.
+ * 레이아웃 넘침 방지(flexShrink) 및 반응형 메타 정보 배치를 지원합니다.
  */
 export default function ChatBubble({
   message,
@@ -31,20 +31,6 @@ export default function ChatBubble({
 }: ChatBubbleProps) {
   const isSent = message.direction === 'SENT';
   const isEditing = editingId === message.id;
-
-  // 수정 모드일 때
-  if (isEditing) {
-    return (
-      <View style={styles.rowRight}>
-        <ChatEditForm
-          value={editText}
-          onChangeText={onEditTextChange}
-          onSave={() => onEditSave(message.id)}
-          onCancel={onEditCancel}
-        />
-      </View>
-    );
-  }
 
   // 상대방 말풍선 (RECEIVED)
   if (!isSent) {
@@ -61,30 +47,53 @@ export default function ChatBubble({
   // 내 말풍선 (SENT)
   return (
     <View style={styles.rowRight}>
-      <LinearGradient
-        colors={[Colors.glass.purple20, Colors.glass.pink20]}
-        start={{ x: 0, y: 0 }}
-        end={{ x: 1, y: 1 }}
-        style={[styles.bubbleBase, styles.sentBubble]}
-      >
-        <Text style={styles.messageText}>{message.text}</Text>
+      {/* 왼쪽 메타 정보: [수정됨]이 [시간] 위에 오도록 세로 배치 */}
+      <View style={styles.metaLeft}>
+        {message.isEdited && <Text style={styles.editedLabel}>수정됨</Text>}
+        <Text style={styles.timestamp}>{message.timestamp}</Text>
+      </View>
 
-        {/* 편집 버튼 & 수정됨 레이블 */}
-        <View style={styles.editRow}>
-          {message.isEdited && (
-            <Text style={styles.editedLabel}>수정됨</Text>
+      {/* 말풍선 컨테이너 (flexShrink 적용으로 레이아웃 넘침 방지) */}
+      <View style={styles.sentBubbleContainer}>
+        <LinearGradient
+          colors={[Colors.glass.purple20, Colors.glass.pink20]}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={[styles.bubbleBase, styles.sentBubble]}
+        >
+          {isEditing ? (
+            // 수정 모드: TextInput이 가용한 가로 공간을 모두 채우도록 flex 적용
+            <View style={styles.editingContent}>
+              <TextInput
+                style={styles.textInput}
+                value={editText}
+                onChangeText={onEditTextChange}
+                multiline
+                autoFocus
+                placeholderTextColor={Colors.neutral.darkGray}
+              />
+              <ChatEditForm
+                onSave={() => onEditSave(message.id)}
+                onCancel={onEditCancel}
+              />
+            </View>
+          ) : (
+            // 일반 모드
+            <Text style={styles.messageText}>{message.text}</Text>
           )}
+        </LinearGradient>
+
+        {/* 수정 버튼: 평상시에만 노출하며 우측 상단 오버랩 */}
+        {!isEditing && (
           <TouchableOpacity
-            style={styles.editButton}
+            style={styles.editButtonAbsolute}
             onPress={() => onEditStart(message.id, message.text)}
-            activeOpacity={0.7}
-            accessibilityLabel="메시지 수정"
+            activeOpacity={0.8}
           >
             <EditPencilIcon width={12} height={12} />
           </TouchableOpacity>
-        </View>
-      </LinearGradient>
-      <Text style={[styles.timestamp, styles.timestampRight]}>{message.timestamp}</Text>
+        )}
+      </View>
     </View>
   );
 }
@@ -92,36 +101,54 @@ export default function ChatBubble({
 const styles = StyleSheet.create({
   rowLeft: {
     alignSelf: 'flex-start',
-    alignItems: 'flex-start',
-    gap: 4,
-    maxWidth: '75%',
+    alignItems: 'flex-end',
+    flexDirection: 'row',
+    gap: 8,
+    maxWidth: '85%',
   },
   rowRight: {
     alignSelf: 'flex-end',
     alignItems: 'flex-end',
-    gap: 4,
-    maxWidth: '75%',
+    flexDirection: 'row',
+    gap: 8,
+    maxWidth: '85%', // 기기 너비에 따른 동적 대응을 위한 퍼센트 너비
+  },
+  metaLeft: {
+    flexDirection: 'column',
+    alignItems: 'flex-end',
+    justifyContent: 'flex-end',
+    gap: 2,
+    minWidth: 40, // 메타 정보 공간 확보
+  },
+  sentBubbleContainer: {
+    position: 'relative',
+    flexShrink: 1, // 중요: 자식(말풍선)이 부모 너비를 넘지 않고 줄어들게 함 (잘림 방지)
   },
   bubbleBase: {
     paddingHorizontal: 12,
-    paddingTop: 12,
-    paddingBottom: 8,
+    paddingVertical: 12,
     borderWidth: 0.612,
   },
   receivedBubble: {
-    borderTopLeftRadius: Radii.bubble,   // 6 — 발신 기원 표시
-    borderTopRightRadius: Radii.lg,      // 16
+    borderTopLeftRadius: Radii.bubble,
+    borderTopRightRadius: Radii.lg,
     borderBottomRightRadius: Radii.lg,
     borderBottomLeftRadius: Radii.lg,
     borderColor: Colors.glass.white10,
     backgroundColor: Colors.glass.white10,
+    flexShrink: 1,
   },
   sentBubble: {
-    borderTopLeftRadius: Radii.lg,      // 16
-    borderTopRightRadius: Radii.bubble, // 6 — 발신 기원 표시
+    borderTopLeftRadius: Radii.lg,
+    borderTopRightRadius: Radii.bubble,
     borderBottomRightRadius: Radii.lg,
     borderBottomLeftRadius: Radii.lg,
     borderColor: Colors.glass.purple30,
+    alignSelf: 'flex-start', // 텍스트 길이에 맞춰 너비 조절
+  },
+  editingContent: {
+    alignSelf: 'stretch',
+    minWidth: 120, // 입력 시 최소 공간 확보
   },
   messageText: {
     color: Colors.neutral.pureWhite,
@@ -131,21 +158,20 @@ const styles = StyleSheet.create({
     lineHeight: 22,
     letterSpacing: -0.15,
   },
-  editRow: {
-    flexDirection: 'row',
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-    gap: 6,
-    marginTop: 4,
-  },
-  editedLabel: {
-    color: Colors.neutral.darkGray,
+  textInput: {
+    color: Colors.neutral.pureWhite,
     fontFamily: 'Inter',
-    fontSize: 12,
-    fontWeight: '400',
-    lineHeight: 16,
+    fontSize: 14,
+    lineHeight: 22,
+    letterSpacing: -0.15,
+    padding: 0,
+    textAlignVertical: 'top',
+    alignSelf: 'stretch',
   },
-  editButton: {
+  editButtonAbsolute: {
+    position: 'absolute',
+    top: -8,
+    right: -8,
     width: 24,
     height: 24,
     justifyContent: 'center',
@@ -153,17 +179,21 @@ const styles = StyleSheet.create({
     borderRadius: Radii.full,
     borderWidth: 0.612,
     borderColor: Colors.glass.purple50,
-    backgroundColor: Colors.glass.purple30,
+    backgroundColor: 'rgba(20, 20, 20, 0.9)',
+    zIndex: 10,
   },
   timestamp: {
     color: Colors.neutral.darkGray,
     fontFamily: 'Inter',
-    fontSize: 12,
+    fontSize: 11,
     fontWeight: '400',
-    lineHeight: 16,
-    paddingHorizontal: 8,
+    lineHeight: 14,
   },
-  timestampRight: {
-    textAlign: 'right',
+  editedLabel: {
+    color: Colors.neutral.darkGray,
+    fontFamily: 'Inter',
+    fontSize: 11,
+    fontWeight: '400',
+    lineHeight: 14,
   },
 });

--- a/mirror-soul/src/components/home/history/detail/parts/ChatEditForm.tsx
+++ b/mirror-soul/src/components/home/history/detail/parts/ChatEditForm.tsx
@@ -3,125 +3,81 @@ import CompleteIcon from '@/assets/images/common/Complete.svg';
 import { Colors, Radii } from '@/src/constants/theme';
 import { LinearGradient } from 'expo-linear-gradient';
 import React from 'react';
-import { StyleSheet, TextInput, TouchableOpacity, View, Text } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 interface ChatEditFormProps {
-  value: string;
-  onChangeText: (text: string) => void;
   onSave: () => void;
   onCancel: () => void;
 }
 
 /**
- * 통화 메시지 수정 폼 (SRP)
- * 내 말풍선(SENT)의 편집 버튼 탭 시 표시됩니다.
+ * 말풍선 내부용 액션 버튼 바 (SRP)
+ * 제자리 수정(In-place) 모드 시 말풍선 하단에 표시됩니다.
  */
-export default function ChatEditForm({
-  value,
-  onChangeText,
-  onSave,
-  onCancel,
-}: ChatEditFormProps) {
+export default function ChatEditForm({ onSave, onCancel }: ChatEditFormProps) {
   return (
-    <View style={styles.container}>
-      {/* TextArea */}
-      <TextInput
-        style={styles.textArea}
-        value={value}
-        onChangeText={onChangeText}
-        multiline
-        textAlignVertical="top"
-        placeholderTextColor={Colors.neutral.darkGray}
-      />
-
-      {/* 버튼 영역 */}
-      <View style={styles.buttonRow}>
-        {/* 저장 버튼 */}
-        <TouchableOpacity
-          style={styles.saveButtonWrapper}
-          onPress={onSave}
-          activeOpacity={0.8}
-          accessibilityRole="button"
-          accessibilityLabel="저장"
+    <View style={styles.buttonRow}>
+      {/* 저장 버튼 */}
+      <TouchableOpacity
+        style={styles.saveButtonWrapper}
+        onPress={onSave}
+        activeOpacity={0.8}
+      >
+        <LinearGradient
+          colors={Colors.gradient.cyanToPurple}
+          start={{ x: 0, y: 0.5 }}
+          end={{ x: 1, y: 0.5 }}
+          style={styles.saveButton}
         >
-          <LinearGradient
-            colors={Colors.gradient.cyanToPurple}
-            start={{ x: 0, y: 0.5 }}
-            end={{ x: 1, y: 0.5 }}
-            style={styles.saveButton}
-          >
-            <CompleteIcon width={14} height={14} />
-            <Text style={styles.saveText}>저장</Text>
-          </LinearGradient>
-        </TouchableOpacity>
+          <CompleteIcon width={12} height={12} />
+          <Text style={styles.saveText}>저장</Text>
+        </LinearGradient>
+      </TouchableOpacity>
 
-        {/* 취소 버튼 */}
-        <TouchableOpacity
-          style={styles.cancelButton}
-          onPress={onCancel}
-          activeOpacity={0.8}
-          accessibilityRole="button"
-          accessibilityLabel="취소"
-        >
-          <CancelIcon width={14} height={14} />
-        </TouchableOpacity>
-      </View>
+      {/* 취소 버튼 */}
+      <TouchableOpacity
+        style={styles.cancelButton}
+        onPress={onCancel}
+        activeOpacity={0.8}
+      >
+        <CancelIcon width={12} height={12} />
+      </TouchableOpacity>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    gap: 14,
-    alignSelf: 'flex-end',
-    maxWidth: '60%',
-  },
-  textArea: {
-    height: 85,
-    borderRadius: Radii.lg,
-    borderWidth: 0.612,
-    borderColor: Colors.glass.purple30,
-    backgroundColor: Colors.glass.purple20,
-    color: Colors.neutral.pureWhite,
-    fontFamily: 'Inter',
-    fontSize: 14,
-    lineHeight: 22,
-    letterSpacing: -0.15,
-    padding: 12,
-  },
   buttonRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 8,
+    gap: 6,
+    marginTop: 10,
     alignSelf: 'stretch',
   },
   saveButtonWrapper: {
     flex: 1,
-    borderRadius: Radii.md2,
+    borderRadius: Radii.md,
     overflow: 'hidden',
   },
   saveButton: {
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    gap: 8,
-    paddingVertical: 8,
-    borderRadius: Radii.md2,
+    gap: 4,
+    paddingVertical: 6,
   },
   saveText: {
     color: Colors.primary.soulBlack,
     fontFamily: 'Inter',
-    fontSize: 14,
+    fontSize: 12,
     fontWeight: '500',
-    lineHeight: 20,
-    letterSpacing: -0.15,
   },
   cancelButton: {
-    width: 36,
-    height: 36,
+    width: 32,
+    height: 32,
     justifyContent: 'center',
     alignItems: 'center',
-    borderRadius: Radii.md2,
+    borderRadius: Radii.md,
     borderWidth: 0.612,
     borderColor: Colors.glass.white10,
     backgroundColor: Colors.glass.white5,

--- a/mirror-soul/src/components/home/history/detail/parts/ChatEditForm.tsx
+++ b/mirror-soul/src/components/home/history/detail/parts/ChatEditForm.tsx
@@ -1,0 +1,129 @@
+import CancelIcon from '@/assets/images/common/Cancel.svg';
+import CompleteIcon from '@/assets/images/common/Complete.svg';
+import { Colors, Radii } from '@/src/constants/theme';
+import { LinearGradient } from 'expo-linear-gradient';
+import React from 'react';
+import { StyleSheet, TextInput, TouchableOpacity, View, Text } from 'react-native';
+
+interface ChatEditFormProps {
+  value: string;
+  onChangeText: (text: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * 통화 메시지 수정 폼 (SRP)
+ * 내 말풍선(SENT)의 편집 버튼 탭 시 표시됩니다.
+ */
+export default function ChatEditForm({
+  value,
+  onChangeText,
+  onSave,
+  onCancel,
+}: ChatEditFormProps) {
+  return (
+    <View style={styles.container}>
+      {/* TextArea */}
+      <TextInput
+        style={styles.textArea}
+        value={value}
+        onChangeText={onChangeText}
+        multiline
+        textAlignVertical="top"
+        placeholderTextColor={Colors.neutral.darkGray}
+      />
+
+      {/* 버튼 영역 */}
+      <View style={styles.buttonRow}>
+        {/* 저장 버튼 */}
+        <TouchableOpacity
+          style={styles.saveButtonWrapper}
+          onPress={onSave}
+          activeOpacity={0.8}
+          accessibilityRole="button"
+          accessibilityLabel="저장"
+        >
+          <LinearGradient
+            colors={Colors.gradient.cyanToPurple}
+            start={{ x: 0, y: 0.5 }}
+            end={{ x: 1, y: 0.5 }}
+            style={styles.saveButton}
+          >
+            <CompleteIcon width={14} height={14} />
+            <Text style={styles.saveText}>저장</Text>
+          </LinearGradient>
+        </TouchableOpacity>
+
+        {/* 취소 버튼 */}
+        <TouchableOpacity
+          style={styles.cancelButton}
+          onPress={onCancel}
+          activeOpacity={0.8}
+          accessibilityRole="button"
+          accessibilityLabel="취소"
+        >
+          <CancelIcon width={14} height={14} />
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: 14,
+    alignSelf: 'flex-end',
+    maxWidth: '60%',
+  },
+  textArea: {
+    height: 85,
+    borderRadius: Radii.lg,
+    borderWidth: 0.612,
+    borderColor: Colors.glass.purple30,
+    backgroundColor: Colors.glass.purple20,
+    color: Colors.neutral.pureWhite,
+    fontFamily: 'Inter',
+    fontSize: 14,
+    lineHeight: 22,
+    letterSpacing: -0.15,
+    padding: 12,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    alignSelf: 'stretch',
+  },
+  saveButtonWrapper: {
+    flex: 1,
+    borderRadius: Radii.md2,
+    overflow: 'hidden',
+  },
+  saveButton: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 8,
+    borderRadius: Radii.md2,
+  },
+  saveText: {
+    color: Colors.primary.soulBlack,
+    fontFamily: 'Inter',
+    fontSize: 14,
+    fontWeight: '500',
+    lineHeight: 20,
+    letterSpacing: -0.15,
+  },
+  cancelButton: {
+    width: 36,
+    height: 36,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: Radii.md2,
+    borderWidth: 0.612,
+    borderColor: Colors.glass.white10,
+    backgroundColor: Colors.glass.white5,
+  },
+});

--- a/mirror-soul/src/components/home/history/detail/parts/ChatEditForm.tsx
+++ b/mirror-soul/src/components/home/history/detail/parts/ChatEditForm.tsx
@@ -22,6 +22,8 @@ export default function ChatEditForm({ onSave, onCancel }: ChatEditFormProps) {
         style={styles.saveButtonWrapper}
         onPress={onSave}
         activeOpacity={0.8}
+        accessibilityRole="button"
+        accessibilityLabel="저장"
       >
         <LinearGradient
           colors={Colors.gradient.cyanToPurple}
@@ -39,6 +41,9 @@ export default function ChatEditForm({ onSave, onCancel }: ChatEditFormProps) {
         style={styles.cancelButton}
         onPress={onCancel}
         activeOpacity={0.8}
+        accessibilityRole="button"
+        accessibilityLabel="취소"
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
       >
         <CancelIcon width={12} height={12} />
       </TouchableOpacity>

--- a/mirror-soul/src/components/home/history/parts/HistoryCallCard.tsx
+++ b/mirror-soul/src/components/home/history/parts/HistoryCallCard.tsx
@@ -1,15 +1,27 @@
 import { Colors, Radii } from '@/src/constants/theme';
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
 import CallProfile from './HistoryCallCard/CallProfile';
 import CallSubInfo from './HistoryCallCard/CallSubInfo';
 import CallTagRow from './HistoryCallCard/CallTagRow';
+
+/**
+ * 통화 내 단일 메시지 데이터 모델 (SRP)
+ */
+export interface ChatMessage {
+  id: string;
+  direction: 'SENT' | 'RECEIVED'; // SENT = 나의 Twin, RECEIVED = 상대방
+  text: string;
+  timestamp: string;               // "11:15" 형식
+  isEdited?: boolean;
+}
 
 export interface HistoryCallItemData {
   id: string;
   name: string;
   age: number;
   consistencyPercent: number;
+  callSequenceNumber: number;      // N번 째 대화
   dateStr: string;
   timeStr: string;
   profileImageUrl?: string;
@@ -18,18 +30,25 @@ export interface HistoryCallItemData {
   durationLabel: string;
   twinMatchLabel: string;
   tags: string[];
+  messages: ChatMessage[];         // 통화 내 메시지 목록
 }
 
 interface HistoryCallCardProps {
   data: HistoryCallItemData;
+  onPress?: () => void;
 }
 
 /**
  * 개별 통화 기록 단위 카드 컴포넌트
  */
-export default function HistoryCallCard({ data }: HistoryCallCardProps) {
+export default function HistoryCallCard({ data, onPress }: HistoryCallCardProps) {
   return (
-    <View style={styles.container}>
+    <TouchableOpacity
+      style={styles.container}
+      onPress={onPress}
+      activeOpacity={0.85}
+      accessibilityRole="button"
+    >
       <CallProfile
         name={data.name}
         age={data.age}
@@ -44,7 +63,7 @@ export default function HistoryCallCard({ data }: HistoryCallCardProps) {
         twinMatchLabel={data.twinMatchLabel}
       />
       <CallTagRow tags={data.tags} />
-    </View>
+    </TouchableOpacity>
   );
 }
 

--- a/mirror-soul/src/constants/theme.ts
+++ b/mirror-soul/src/constants/theme.ts
@@ -17,6 +17,7 @@ export const Colors = {
     darkGray: '#6A7282',
     disabledText: '#4A5565',
     lightGrayText: '#D1D5DC',
+    lavender: '#DAB2FF',           // 통화 상세 알림 텍스트
   },
   glass: {
     white5: 'rgba(255, 255, 255, 0.05)',
@@ -43,6 +44,9 @@ export const Colors = {
     black40: 'rgba(0, 0, 0, 0.40)', // 답변 박스 배경
     black50: 'rgba(0, 0, 0, 0.50)', // 추천 카드 배지 배경
     black80: 'rgba(0, 0, 0, 0.80)', // 추천 카드 정보 그라디언트
+    purple10: 'rgba(194, 122, 255, 0.10)', // 통화 상세 알림 배너 배경
+    purple50: 'rgba(194, 122, 255, 0.50)', // 편집 버튼 테두리
+    pink20: 'rgba(251, 100, 182, 0.20)',   // 내 말풍선 그라디언트 끝색
     recordingBg: ['rgba(0, 211, 243, 0.05)', 'rgba(194, 122, 255, 0.05)'] as [string, string], // 웨이브폼 배경
   }
 };
@@ -55,6 +59,7 @@ export const Radii = {
   none: 0,
   xs: 4,
   sm: 8,
+  bubble: 6, // 말풍선 origin 모서리 (진입 방향 표시용)
   smmd: 10,   // 통화 서브 정보 등 추가분
   md: 12,
   md2: 14,    // 버튼, 드롭다운, 카드 등 범용 (피그마 명칭 미정)

--- a/mirror-soul/src/mocks/historyMocks.ts
+++ b/mirror-soul/src/mocks/historyMocks.ts
@@ -1,0 +1,89 @@
+import { HistoryCallItemData } from '@/src/components/home/history/parts/HistoryCallCard';
+
+/**
+ * 통화 기록 Mock 데이터 (임시 — API 연동 시 제거)
+ * HistoryList 및 CallDetail 화면에서 공유 사용합니다.
+ */
+export const MOCK_CALL_HISTORY: HistoryCallItemData[] = [
+  {
+    id: '1',
+    name: '수빈',
+    age: 28,
+    consistencyPercent: 94,
+    callSequenceNumber: 2,
+    dateStr: '오늘',
+    timeStr: '14:30',
+    direction: 'SENT',
+    callTypeDesc: '내가 시작한 통화',
+    durationLabel: '8분 23초',
+    twinMatchLabel: '상대 Twin 92%',
+    tags: ['음악', '전시회', '크리에이티브'],
+    messages: [
+      {
+        id: 'm1',
+        direction: 'RECEIVED',
+        text: '안녕하세요! 처음 뵙겠습니다.',
+        timestamp: '11:15',
+      },
+      {
+        id: 'm2',
+        direction: 'SENT',
+        text: '안녕하세요 수빈님! 반가워요.',
+        timestamp: '11:15',
+      },
+      {
+        id: 'm3',
+        direction: 'RECEIVED',
+        text: '프로필 보니까 요가에 관심 있으시던데, 저도 요가를 정말 좋아해요!',
+        timestamp: '11:16',
+      },
+      {
+        id: 'm4',
+        direction: 'SENT',
+        text: '오 정말요? 저는 주로 아침에 하는데, 수빈님는 언제 하세요?',
+        timestamp: '11:16',
+        isEdited: true,
+      },
+      {
+        id: 'm5',
+        direction: 'RECEIVED',
+        text: '저는 퇴근 후에 주로 해요. 하루의 스트레스를 풀기에 딱 좋더라구요.',
+        timestamp: '11:17',
+      },
+      {
+        id: 'm6',
+        direction: 'SENT',
+        text: '그것도 좋은 방법이네요! 명상도 같이 하시나요?',
+        timestamp: '11:18',
+      },
+    ],
+  },
+  {
+    id: '2',
+    name: '지우',
+    age: 26,
+    consistencyPercent: 88,
+    callSequenceNumber: 1,
+    dateStr: '어제',
+    timeStr: '21:15',
+    direction: 'RECEIVED',
+    callTypeDesc: '상대방이 시작한 통화',
+    durationLabel: '12분 40초',
+    twinMatchLabel: '상대 Twin 85%',
+    tags: ['여행', '맛집'],
+    messages: [
+      {
+        id: 'm1',
+        direction: 'RECEIVED',
+        text: '안녕하세요! 지우예요.',
+        timestamp: '21:15',
+      },
+      {
+        id: 'm2',
+        direction: 'SENT',
+        text: '안녕하세요 지우님! 처음 이야기 나눠보네요.',
+        timestamp: '21:15',
+      },
+    ],
+  },
+];


### PR DESCRIPTION
## 💡 작업 동기 및 목적
- 이 PR이 왜 필요한가요? (어떤 기능 추가/버그 수정인지 설명)
- 연관된 이슈 번호가 있다면 적어주세요. (예: Close #58 )

## 📝 변경 사항
- 이 PR에서 핵심적으로 변경된 부분을 요약해주세요.
  - [x] 예: `LoginPage.tsx`에 SNS 로그인 버튼 추가
  - [x] 예: 라우팅 구조 변경 및 리다이렉트 처리 로직 버그 수정

## 📸 스크린샷 (선택)
- UI 변경이 있다면 전/후 사진이나 구현된 화면을 첨부해주세요. (없으면 지우셔도 무방합니다)

## 🧐 리뷰 포인트 / 기타 특이사항
- 특별히 고민했던 로직이나, 나중에 다시 보거나 리팩토링할 필요가 있는 부분이 있나요?
  - (예시) *카카오 로그인 리다이렉트 로직이 아직 매끄럽지 않아서 임시로 setTimeout 처리를 해두었습니다.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 통화 기록 상세 조회 화면 추가 - 과거 대화 내용을 확인할 수 있습니다.
  * 메시지 편집 기능 - 통화 상세 화면에서 이전 메시지를 수정 및 저장할 수 있습니다.
  * 통화 일관성 지표 및 상세 정보 표시 - 상단 헤더에서 Twin 학습 일관성 정보를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->