### PR TITLE
feat: matching_recommend UI 구현

### DIFF
--- a/mirror-soul/app/(main)/match.tsx
+++ b/mirror-soul/app/(main)/match.tsx
@@ -1,17 +1,18 @@
-import MatchingActiveBanner from '@/src/components/home/match/parts/MatchingActiveBanner';
-import MatchingCard from '@/src/components/home/match/parts/MatchingCard';
-import MatchingFooter from '@/src/components/home/match/parts/MatchingFooter';
-import MatchingHeader from '@/src/components/home/match/parts/MatchingHeader';
-import MatchingSummaryRow from '@/src/components/home/match/parts/MatchingSummaryRow';
-import MatchingTabIndicator from '@/src/components/home/match/parts/MatchingTabIndicator';
 import { Colors, Layout } from '@/src/constants/theme';
 import React from 'react';
-import { FlatList, SafeAreaView, ScrollView, StyleSheet, useWindowDimensions, View } from 'react-native';
+import { StyleSheet, View, ScrollView, SafeAreaView, useWindowDimensions, FlatList, Animated } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import MatchingHeader from '@/src/components/home/match/parts/MatchingHeader';
+import MatchingActiveBanner from '@/src/components/home/match/parts/MatchingActiveBanner';
+import MatchingSummaryRow, { MatchingTabType } from '@/src/components/home/match/parts/MatchingSummaryRow';
+import MatchingTabIndicator from '@/src/components/home/match/parts/MatchingTabIndicator';
+import MatchingMeetCard from '@/src/components/home/match/parts/cards/MatchingMeetCard';
+import MatchingRecommendCard from '@/src/components/home/match/parts/cards/MatchingRecommendCard';
+import MatchingFooter from '@/src/components/home/match/parts/MatchingFooter';
 
-const MATCH_DATA = [
+const MEET_DATA = [
   {
-    id: '1',
+    id: 'm1',
     name: '민주',
     age: 27,
     timeAgo: '15분 전',
@@ -20,7 +21,7 @@ const MATCH_DATA = [
     summaries: ['음악 취향이 비슷해요', '여행 이야기로 공감대 형성', '대화 스타일이 편안했어요'],
   },
   {
-    id: '2',
+    id: 'm2',
     name: '지수',
     age: 25,
     timeAgo: '30분 전',
@@ -30,16 +31,62 @@ const MATCH_DATA = [
   },
 ];
 
+const RECOMMEND_DATA = [
+  {
+    id: 'r1',
+    name: '지연',
+    age: 23,
+    bio: '요가 강사이자 명상을 좋아하는 평화로운 영혼',
+    reasons: ['둘 다 웰빙과 자기계발에 관심', '조용하고 깊이 있는 대화 선호', '비슷한 라이프스타일'],
+    avgCallMinutes: 16,
+    tags: ['헬스', '식단'],
+  },
+  {
+    id: 'r2',
+    name: '수현',
+    age: 26,
+    bio: 'IT 개발자이자 주말에는 밴드 활동을 하는 베이시스트',
+    reasons: ['음악적 취향의 높은 일치도', '기술과 예술에 대한 공통 관심사', '활발한 대화 스타일'],
+    avgCallMinutes: 24,
+    tags: ['재즈', '코딩'],
+  },
+];
+
 /**
  * 매칭 화면 (Main)
  */
 export default function MatchScreen() {
   const { width } = useWindowDimensions();
   const insets = useSafeAreaInsets();
+  const [activeTab, setActiveTab] = React.useState<MatchingTabType>('meet');
   const [activeIndex, setActiveIndex] = React.useState(0);
-
+  const fadeAnim = React.useRef(new Animated.Value(1)).current;
+  const flatListRef = React.useRef<FlatList>(null);
+  
   // 피그마 기준 가로 패딩 적용
   const horizontalPadding = (width * 19.996) / 392.927;
+
+  // 탭 전환 핸들러 (애니메이션 포함)
+  const handleTabChange = (tab: MatchingTabType) => {
+    if (tab === 'twin') return; // Twin 탭은 추후 구현
+    if (tab === activeTab) return;
+    
+    Animated.timing(fadeAnim, {
+      toValue: 0,
+      duration: 150,
+      useNativeDriver: true,
+    }).start(() => {
+      setActiveTab(tab);
+      setActiveIndex(0);
+      flatListRef.current?.scrollToOffset({ offset: 0, animated: false });
+      
+      Animated.timing(fadeAnim, {
+        toValue: 1,
+        duration: 200,
+        useNativeDriver: true,
+      }).start();
+    });
+  };
 
   // 스크롤 종료 시 인덱스 계산
   const onMomentumScrollEnd = (event: any) => {
@@ -48,9 +95,12 @@ export default function MatchScreen() {
     setActiveIndex(index);
   };
 
+  const currentData = activeTab === 'meet' ? MEET_DATA : RECOMMEND_DATA;
+  const activeColor = activeTab === 'meet' ? Colors.primary.mirrorOrange : Colors.primary.vividPurple;
+
   return (
     <SafeAreaView style={styles.safeArea}>
-      <ScrollView
+      <ScrollView 
         style={styles.scrollView}
         contentContainerStyle={[
           styles.scrollContent,
@@ -59,18 +109,23 @@ export default function MatchScreen() {
         showsVerticalScrollIndicator={false}
       >
         <View style={styles.container}>
-          {/* 상단 섹션: 헤더 ~ 인디케이터 (개별 패딩 적용) */}
+          {/* 상단 섹션 */}
           <View style={[styles.topSection, { paddingHorizontal: horizontalPadding }]}>
             <MatchingHeader />
             <MatchingActiveBanner />
-            <MatchingSummaryRow />
-            <MatchingTabIndicator activeIndex={activeIndex} total={MATCH_DATA.length} />
+            <MatchingSummaryRow activeTab={activeTab} onTabChange={handleTabChange} />
+            <MatchingTabIndicator 
+              activeIndex={activeIndex} 
+              total={currentData.length} 
+              activeColor={activeColor}
+            />
           </View>
 
-          {/* 중앙 섹션: 카드 영역 (가로 스크롤 가능, 높이 가변) */}
-          <View style={styles.cardSection}>
+          {/* 중앙 섹션 (카드 영역) */}
+          <Animated.View style={[styles.cardSection, { opacity: fadeAnim }]}>
             <FlatList
-              data={MATCH_DATA}
+              ref={flatListRef}
+              data={currentData}
               keyExtractor={(item) => item.id}
               horizontal
               pagingEnabled
@@ -78,7 +133,11 @@ export default function MatchScreen() {
               onMomentumScrollEnd={onMomentumScrollEnd}
               renderItem={({ item }) => (
                 <View style={{ width: width, paddingHorizontal: horizontalPadding }}>
-                  <MatchingCard {...item} />
+                  {activeTab === 'meet' ? (
+                    <MatchingMeetCard {...item} />
+                  ) : (
+                    <MatchingRecommendCard {...item} />
+                  )}
                 </View>
               )}
               snapToInterval={width}
@@ -86,11 +145,11 @@ export default function MatchScreen() {
               snapToAlignment="center"
               contentContainerStyle={{ alignItems: 'flex-start' }}
             />
-          </View>
+          </Animated.View>
 
-          {/* 하단 섹션: 푸터 (개별 패딩 적용) */}
+          {/* 하단 섹션 */}
           <View style={[styles.bottomSection, { paddingHorizontal: horizontalPadding }]}>
-            <MatchingFooter />
+            <MatchingFooter activeTab={activeTab} />
           </View>
         </View>
       </ScrollView>

--- a/mirror-soul/src/components/home/match/parts/MatchingFooter.tsx
+++ b/mirror-soul/src/components/home/match/parts/MatchingFooter.tsx
@@ -1,14 +1,23 @@
 import { Colors, Radii } from '@/src/constants/theme';
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import { MatchingTabType } from './MatchingSummaryRow';
+
+interface MatchingFooterProps {
+  activeTab: MatchingTabType;
+}
 
 /**
  * 매칭 화면 하단 안내 배너
  */
-export default function MatchingFooter() {
+export default function MatchingFooter({ activeTab }: MatchingFooterProps) {
+  const footerText = activeTab === 'recommend' 
+    ? '통화 패턴을 분석하여 추천해드려요' 
+    : '상대방이 직접 당신과 통화하고 싶어해요';
+
   return (
     <View style={styles.container}>
-      <Text style={styles.text}>상대방이 직접 당신과 통화하고 싶어해요</Text>
+      <Text style={styles.text}>{footerText}</Text>
     </View>
   );
 }

--- a/mirror-soul/src/components/home/match/parts/MatchingSummaryRow.tsx
+++ b/mirror-soul/src/components/home/match/parts/MatchingSummaryRow.tsx
@@ -1,45 +1,100 @@
-import MeetIcon from '@/assets/images/common/matching/MeetIcon.svg';
+import NoMeetingIcon from '@/assets/images/common/matching/NoMeeting.svg';
 import TwinCallIcon from '@/assets/images/common/matching/TwinCall.svg';
-import RecommendIcon from '@/assets/images/common/matching/MatchingRecommend.svg';
+import OnRecommendIcon from '@/assets/images/common/matching/OnRecommend.svg';
 import { Colors, Radii } from '@/src/constants/theme';
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
+export type MatchingTabType = 'meet' | 'twin' | 'recommend';
+
+interface MatchingSummaryRowProps {
+  activeTab: MatchingTabType;
+  onTabChange: (tab: MatchingTabType) => void;
+}
+
 /**
  * 매칭 요약 버튼 행 (만남 신청, Twin, 추천)
  */
-export default function MatchingSummaryRow() {
+export default function MatchingSummaryRow({ activeTab, onTabChange }: MatchingSummaryRowProps) {
   return (
     <View style={styles.container}>
       {/* 만남 신청 버튼 */}
-      <TouchableOpacity activeOpacity={0.8} style={[styles.summaryButton, styles.meetButton]}>
+      <TouchableOpacity 
+        activeOpacity={0.8} 
+        onPress={() => onTabChange('meet')}
+        style={[
+          styles.summaryButton, 
+          activeTab === 'meet' && styles.meetButtonActive
+        ]}
+      >
         <View style={styles.buttonContent}>
-          <MeetIcon width={20} height={20} />
-          <Text style={[styles.buttonText, { color: Colors.primary.mirrorOrange }]}>만남 신청</Text>
-          <View style={[styles.badge, { backgroundColor: Colors.glass.orange30 }]}>
-            <Text style={[styles.badgeText, { color: Colors.primary.mirrorOrange }]}>2</Text>
+          <NoMeetingIcon width={20} height={20} />
+          <Text style={[
+            styles.buttonText, 
+            activeTab === 'meet' && { color: Colors.primary.mirrorOrange }
+          ]}>만남 신청</Text>
+          <View style={[
+            styles.badge, 
+            { backgroundColor: activeTab === 'meet' ? Colors.glass.orange30 : 'rgba(255, 137, 4, 0.30)' }
+          ]}>
+            <Text style={[
+              styles.badgeText, 
+              activeTab === 'meet' && { color: Colors.primary.mirrorOrange }
+            ]}>2</Text>
           </View>
         </View>
       </TouchableOpacity>
 
       {/* Twin 버튼 */}
-      <TouchableOpacity activeOpacity={0.8} style={styles.summaryButton}>
+      <TouchableOpacity 
+        activeOpacity={0.8} 
+        onPress={() => onTabChange('twin')}
+        style={[
+          styles.summaryButton, 
+          activeTab === 'twin' && styles.twinButtonActive
+        ]}
+      >
         <View style={styles.buttonContent}>
           <TwinCallIcon width={20} height={20} />
-          <Text style={styles.buttonText}>Twin</Text>
-          <View style={[styles.badge, { backgroundColor: Colors.glass.cyan30 }]}>
-            <Text style={styles.badgeText}>2</Text>
+          <Text style={[
+            styles.buttonText, 
+            activeTab === 'twin' && { color: Colors.primary.electricCyan }
+          ]}>Twin</Text>
+          <View style={[
+            styles.badge, 
+            { backgroundColor: activeTab === 'twin' ? Colors.glass.cyan30 : 'rgba(0, 211, 243, 0.30)' }
+          ]}>
+            <Text style={[
+              styles.badgeText, 
+              activeTab === 'twin' && { color: Colors.primary.electricCyan }
+            ]}>2</Text>
           </View>
         </View>
       </TouchableOpacity>
 
       {/* 추천 버튼 */}
-      <TouchableOpacity activeOpacity={0.8} style={styles.summaryButton}>
+      <TouchableOpacity 
+        activeOpacity={0.8} 
+        onPress={() => onTabChange('recommend')}
+        style={[
+          styles.summaryButton, 
+          activeTab === 'recommend' && styles.recommendButtonActive
+        ]}
+      >
         <View style={styles.buttonContent}>
-          <RecommendIcon width={20} height={20} />
-          <Text style={styles.buttonText}>추천</Text>
-          <View style={[styles.badge, { backgroundColor: Colors.glass.purple30 }]}>
-            <Text style={styles.badgeText}>2</Text>
+          <OnRecommendIcon width={20} height={20} />
+          <Text style={[
+            styles.buttonText, 
+            activeTab === 'recommend' && { color: Colors.primary.vividPurple }
+          ]}>추천</Text>
+          <View style={[
+            styles.badge, 
+            { backgroundColor: activeTab === 'recommend' ? Colors.glass.purple30 : 'rgba(194, 122, 255, 0.30)' }
+          ]}>
+            <Text style={[
+              styles.badgeText, 
+              activeTab === 'recommend' && { color: Colors.primary.vividPurple }
+            ]}>2</Text>
           </View>
         </View>
       </TouchableOpacity>
@@ -63,9 +118,17 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     paddingHorizontal: 4,
   },
-  meetButton: {
+  meetButtonActive: {
     borderColor: Colors.glass.orange30,
     backgroundColor: Colors.glass.orange20,
+  },
+  twinButtonActive: {
+    borderColor: Colors.glass.cyan30,
+    backgroundColor: Colors.glass.cyan20,
+  },
+  recommendButtonActive: {
+    borderColor: Colors.glass.purple30,
+    backgroundColor: Colors.glass.purple20,
   },
   buttonContent: {
     flexDirection: 'row',

--- a/mirror-soul/src/components/home/match/parts/MatchingTabIndicator.tsx
+++ b/mirror-soul/src/components/home/match/parts/MatchingTabIndicator.tsx
@@ -5,18 +5,26 @@ import { StyleSheet, View } from 'react-native';
 interface MatchingTabIndicatorProps {
   activeIndex: number;
   total: number;
+  activeColor?: string;
 }
 
 /**
- * 매칭 화면 탭 인디케이터 (오렌지 바 + 회색 점)
+ * 매칭 화면 탭 인디케이터 (색상 가변 바 + 회색 점)
  */
-export default function MatchingTabIndicator({ activeIndex, total }: MatchingTabIndicatorProps) {
+export default function MatchingTabIndicator({ 
+  activeIndex, 
+  total, 
+  activeColor = Colors.primary.mirrorOrange 
+}: MatchingTabIndicatorProps) {
   return (
     <View style={styles.container}>
       {Array.from({ length: total }).map((_, index) => (
         <View 
           key={index} 
-          style={index === activeIndex ? styles.activeBar : styles.inactiveDot} 
+          style={[
+            index === activeIndex ? styles.activeBar : styles.inactiveDot,
+            index === activeIndex && { backgroundColor: activeColor }
+          ]} 
         />
       ))}
     </View>

--- a/mirror-soul/src/components/home/match/parts/cards/MatchingMeetCard.tsx
+++ b/mirror-soul/src/components/home/match/parts/cards/MatchingMeetCard.tsx
@@ -20,16 +20,16 @@ interface MatchingCardProps {
 }
 
 /**
- * 매칭 메인 카드 컴포넌트
+ * 매칭 만남 신청 카드 컴포넌트
  */
-export default function MatchingCard({
+export default function MatchingMeetCard({
   name = '민주',
   age = 27,
   timeAgo = '15분 전',
   twinSatisfaction = 73,
   message = 'Twin과 대화가 정말 즐거웠어요! 직접 만나서 커피 한잔 하면서 음악 이야기 더 나누고 싶어요 😊',
   summaries = ['음악 취향이 비슷해요', '여행 이야기로 공감대 형성', '대화 스타일이 편안했어요'],
-}: Partial<MatchingCardProps>) {
+}: Partial<MatchingMeetCardProps>) {
   return (
     <View style={styles.container}>
       {/* 1. 상단 프로필 카드 (Container1) - 콘텐츠 기반 가변 높이 */}

--- a/mirror-soul/src/components/home/match/parts/cards/MatchingRecommendCard.tsx
+++ b/mirror-soul/src/components/home/match/parts/cards/MatchingRecommendCard.tsx
@@ -1,0 +1,300 @@
+import React from 'react';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Colors, Radii } from '@/src/constants/theme';
+
+// 아이콘 에셋
+import SummaryIcon from '@/assets/images/common/matching/RemmendSummary.svg';
+import CallStyleIcon from '@/assets/images/common/matching/Call_Style.svg';
+import TimerIcon from '@/assets/images/common/matching/Call_Style_Timer.svg';
+import CancelIcon from '@/assets/images/common/Cancel.svg';
+import TwinCallButtonIcon from '@/assets/images/common/matching/TwinCallButton.svg';
+
+interface MatchingRecommendCardProps {
+  name: string;
+  age: number;
+  bio: string;
+  reasons: string[];
+  avgCallMinutes: number;
+  tags: string[];
+}
+
+/**
+ * 추천 탭 전용 카드 컴포넌트
+ */
+export default function MatchingRecommendCard({
+  name = '지연',
+  age = 23,
+  bio = '요가 강사이자 명상을 좋아하는 평화로운 영혼',
+  reasons = ['둘 다 웰빙과 자기계발에 관심', '조용하고 깊이 있는 대화 선호', '비슷한 라이프스타일'],
+  avgCallMinutes = 16,
+  tags = ['헬스', '식단'],
+}: Partial<MatchingRecommendCardProps>) {
+  return (
+    <View style={styles.container}>
+      {/* 메인 카드 영역 */}
+      <View style={styles.mainCard}>
+        {/* 1. 프로필 섹션 (헤더 그라디언트) */}
+        <LinearGradient
+          colors={Colors.gradient.twinCardHeader}
+          start={{ x: 0, y: 0 }}
+          end={{ x: 1, y: 1 }}
+          style={styles.profileSection}
+        >
+          <View style={styles.profileRow}>
+            {/* 프로필 이미지 (목업 그라디언트) */}
+            <LinearGradient
+              colors={[Colors.glass.purple30, Colors.glass.pink30]}
+              style={styles.profileImage}
+            />
+            
+            <View style={styles.profileInfo}>
+              <Text style={styles.nameText}>{name}, {age}</Text>
+              <Text style={styles.bioText} numberOfLines={2}>
+                {bio}
+              </Text>
+            </View>
+          </View>
+        </LinearGradient>
+
+        {/* 2. 추천 이유 섹션 */}
+        <View style={styles.summarySection}>
+          <View style={styles.sectionTitleRow}>
+            <SummaryIcon width={16} height={16} />
+            <Text style={styles.sectionTitle}>추천 드린 이유</Text>
+          </View>
+          
+          <View style={styles.reasonList}>
+            {reasons.map((reason, index) => (
+              <View key={index} style={styles.reasonItem}>
+                <View style={styles.dot} />
+                <Text style={styles.reasonText}>{reason}</Text>
+              </View>
+            ))}
+          </View>
+        </View>
+
+        {/* 3. 통화 스타일 섹션 */}
+        <View style={styles.callStyleSection}>
+          <View style={styles.sectionTitleRow}>
+            <CallStyleIcon width={16} height={16} />
+            <Text style={styles.sectionTitle}>통화 스타일</Text>
+          </View>
+          
+          <View style={styles.callStyleBox}>
+            <View style={styles.avgTimeRow}>
+              <TimerIcon width={16} height={16} />
+              <Text style={styles.avgTimeText}>평균 {avgCallMinutes}분</Text>
+            </View>
+            
+            <View style={styles.tagRow}>
+              {tags.map((tag, index) => (
+                <View key={index} style={styles.tagBadge}>
+                  <Text style={styles.tagText}>{tag}</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        </View>
+      </View>
+
+      {/* 하단 액션 버튼 영역 */}
+      <View style={styles.actionRow}>
+        <TouchableOpacity activeOpacity={0.8} style={styles.cancelButton}>
+          <CancelIcon width={24} height={24} />
+          <Text style={styles.cancelButtonText}>건너뛰기</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity activeOpacity={0.8} style={styles.callButtonContainer}>
+          <LinearGradient
+            colors={Colors.gradient.twinCallButton}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 0 }}
+            style={styles.callButton}
+          >
+            <TwinCallButtonIcon width={20} height={20} />
+            <Text style={styles.callButtonText}>상대 Twin과 통화</Text>
+          </LinearGradient>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignSelf: 'stretch',
+    gap: 16,
+  },
+  mainCard: {
+    borderRadius: Radii.lg,
+    borderWidth: 0.612,
+    borderColor: Colors.glass.white20,
+    backgroundColor: Colors.glass.white05,
+    overflow: 'hidden',
+  },
+  profileSection: {
+    padding: 20,
+    borderBottomWidth: 0.612,
+    borderColor: Colors.glass.white10,
+  },
+  profileRow: {
+    flexDirection: 'row',
+    gap: 16,
+    alignItems: 'center',
+  },
+  profileImage: {
+    width: 80,
+    height: 80,
+    borderRadius: Radii.lg,
+    borderWidth: 0.612,
+    borderColor: Colors.glass.white20,
+  },
+  profileInfo: {
+    flex: 1,
+    gap: 8,
+  },
+  nameText: {
+    color: Colors.neutral.pureWhite,
+    fontFamily: 'Inter',
+    fontSize: 20,
+    fontWeight: '500',
+    lineHeight: 28,
+    letterSpacing: -0.45,
+  },
+  bioText: {
+    color: Colors.neutral.lightGray,
+    fontFamily: 'Inter',
+    fontSize: 14,
+    fontWeight: '400',
+    lineHeight: 22.75,
+    letterSpacing: -0.15,
+  },
+  summarySection: {
+    padding: 20,
+    gap: 12,
+    borderBottomWidth: 0.612,
+    borderColor: Colors.glass.white10,
+  },
+  sectionTitleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  sectionTitle: {
+    color: Colors.neutral.pureWhite,
+    fontFamily: 'Inter',
+    fontSize: 14,
+    fontWeight: '500',
+    lineHeight: 20,
+    letterSpacing: -0.15,
+  },
+  reasonList: {
+    gap: 8,
+  },
+  reasonItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: Radii.full,
+    backgroundColor: Colors.primary.vividPurple,
+  },
+  reasonText: {
+    color: Colors.neutral.lightGrayText,
+    fontFamily: 'Inter',
+    fontSize: 14,
+    fontWeight: '400',
+    lineHeight: 20,
+    letterSpacing: -0.15,
+  },
+  callStyleSection: {
+    padding: 20,
+    gap: 12,
+  },
+  callStyleBox: {
+    padding: 12,
+    borderRadius: Radii.md2,
+    borderWidth: 0.612,
+    borderColor: Colors.glass.purple20,
+    backgroundColor: Colors.glass.purple10,
+    gap: 8,
+  },
+  avgTimeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  avgTimeText: {
+    color: Colors.neutral.lightGrayText,
+    fontFamily: 'Inter',
+    fontSize: 14,
+    fontWeight: '400',
+    lineHeight: 20,
+    letterSpacing: -0.15,
+  },
+  tagRow: {
+    flexDirection: 'row',
+    gap: 6,
+  },
+  tagBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: Radii.full,
+    backgroundColor: Colors.glass.purple20,
+  },
+  tagText: {
+    color: Colors.neutral.lavender,
+    fontFamily: 'Inter',
+    fontSize: 12,
+    fontWeight: '400',
+    lineHeight: 16,
+  },
+  actionRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  cancelButton: {
+    flex: 1,
+    height: 57,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    borderRadius: Radii.md2,
+    borderWidth: 0.612,
+    borderColor: Colors.glass.white10,
+    backgroundColor: Colors.glass.white05,
+  },
+  cancelButtonText: {
+    color: Colors.neutral.pureWhite,
+    fontFamily: 'Inter',
+    fontSize: 16,
+    fontWeight: '500',
+    lineHeight: 24,
+    letterSpacing: -0.31,
+  },
+  callButtonContainer: {
+    flex: 1,
+    height: 57,
+  },
+  callButton: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    borderRadius: Radii.md2,
+  },
+  callButtonText: {
+    color: '#000', // 검정색 텍스트
+    fontFamily: 'Inter',
+    fontSize: 16,
+    fontWeight: '500',
+    lineHeight: 24,
+    letterSpacing: -0.31,
+  },
+});

--- a/mirror-soul/src/constants/theme.ts
+++ b/mirror-soul/src/constants/theme.ts
@@ -19,6 +19,8 @@ export const Colors = {
     meetProgress: ['#FF8904', '#FF6467'] as [string, string], // 만족도 바 및 통화 버튼
     cardHeader: ['rgba(255, 137, 4, 0.10)', 'rgba(255, 100, 103, 0.10)'] as [string, string], // 매칭 카드 헤더
     matchingStart: ['#FB64B6', '#C27AFF'] as [string, string], // 시작 버튼 전용
+    twinCardHeader: ['rgba(194, 122, 255, 0.10)', 'rgba(251, 100, 182, 0.10)'] as [string, string], // Twin 카드 헤더
+    twinCallButton: ['#C27AFF', '#FB64B6'] as [string, string], // 상대 Twin과 통화 버튼
   },
   neutral: {
     pureWhite: '#FFFFFF',


### PR DESCRIPTION
💡 작업 동기 및 목적
매칭 메인 화면의 사용자 경험 고도화를 위해 '만남 신청'과 '추천' 탭을 분리하고, 각 탭의 성격에 맞는 차별화된 카드 UI 및 인터랙션을 구현했습니다.
탭 전환 시 시각적 즐거움을 줄 수 있는 애니메이션 효과를 추가하고, 데이터 구조를 체계화하여 향후 확장성(Twin 탭 등)을 확보했습니다.
연관된 이슈: Close #67 

📝 변경 사항
UI 컴포넌트 아키텍처 개선
 매칭 카드들을 기능별로 관리하기 위해 parts/cards/ 폴더 구조 도입
 기존 MatchingCard.tsx를 MatchingMeetCard.tsx로 이동 및 리네임
추천(Recommend) 탭 신규 기능 개발
 MatchingRecommendCard.tsx 신규 생성: 퍼플 테마의 고도화된 프로필/통화 스타일 카드 구현
 RECOMMEND_DATA 더미 데이터 구축 및 가로 스와이프 기능 연동
인터랙션 및 UX 고도화
 match.tsx 내 탭 전환 시 Fade In/Out 크로스페이드 애니메이션 적용
 MatchingSummaryRow.tsx 수정: 탭별 활성화 스타일(컬러, 보더, 배지) 동적 적용
 MatchingTabIndicator.tsx 개선: 활성 탭 컬러(오렌지/퍼플) 동적 연동
 MatchingFooter.tsx 조건부 렌더링: 탭 성격에 맞는 안내 문구 노출 ("통화 패턴 분석..." 등)
디자인 시스템 확장
 theme.ts에 추천 카드 전용 그라디언트 및 글래스 컬러 토큰 추가

📸 스크린샷
(이곳에 실제 시뮬레이터 캡처 이미지를 첨부하시면 더욱 좋습니다.)

만남 신청 탭: 기존 오렌지 테마 유지 및 "직접 통화하고 싶어해요" 푸터 노출
추천 탭: 보라색 테마의 신규 카드 UI 및 "통화 패턴 분석..." 푸터 노출


🧐 리뷰 포인트 / 기타 특이사항
애니메이션 처리: Animated API를 사용하여 탭 전환 시 기존 카드가 페이드 아웃된 후 상태가 변경되고 다시 페이드 인 되도록 설계했습니다. 혹시 전환 속도가 너무 빠르거나 느리게 느껴지지 않는지 확인 부탁드립니다.
Twin 탭 확장성: 현재 Twin 탭은 로직상 클릭이 막혀 있으나(handleTabChange 내 예외 처리), 추후 UI가 준비되는 대로 MatchingRecommendCard와 유사한 방식으로 쉽게 추가할 수 있도록 구조를 잡아두었습니다.
인디케이터 로직: 탭을 바꿀 때 FlatList의 인덱스를 0으로 초기화하여 사용자 혼란을 방지했습니다.