### PR TITLE
feat: Self 인터뷰 코드 구현

### DIFF
--- a/mirror-soul/app/ai-call.tsx
+++ b/mirror-soul/app/ai-call.tsx
@@ -1,0 +1,51 @@
+import React, { useEffect } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Colors } from '@/src/constants/theme';
+import { useAICallFlow } from '@/src/hooks/useAICallFlow';
+import CallHeader from '@/src/components/call/CallHeader';
+import CallAIAvatar from '@/src/components/call/CallAIAvatar';
+import CallControls from '@/src/components/call/CallControls';
+
+/**
+ * AI 트윈 음성 통화 화면
+ *
+ * 진입 경로: Grow 탭 → 나를 알아가는 인터뷰 카드 클릭
+ * 통화 종료 후 자동으로 이전 화면으로 돌아갑니다.
+ */
+export default function AICallScreen() {
+  const router = useRouter();
+  const { callStatus, remoteStream, startCall, hangUp, error } = useAICallFlow();
+
+  // 통화 종료 시 화면 이탈
+  useEffect(() => {
+    if (callStatus === 'ended') {
+      router.back();
+    }
+  }, [callStatus, router]);
+
+  return (
+    <View style={styles.container}>
+      {/* 상태 헤더 */}
+      <CallHeader callStatus={callStatus} />
+
+      {/* AI 아바타 (음성 활성 시 펄스 애니메이션) */}
+      <CallAIAvatar callStatus={callStatus} />
+
+      {/* 통화 제어 버튼 */}
+      <CallControls
+        callStatus={callStatus}
+        onStartCall={startCall}
+        onHangUp={hangUp}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.primary.soulBlack,
+    paddingTop: 60,
+  },
+});

--- a/mirror-soul/package-lock.json
+++ b/mirror-soul/package-lock.json
@@ -46,6 +46,7 @@
         "react-native-vision-camera": "~4.7.3",
         "react-native-vision-camera-face-detector": "~1.10.2",
         "react-native-web": "~0.21.0",
+        "react-native-webrtc": "^124.0.7",
         "react-native-worklets": "0.5.1",
         "react-native-worklets-core": "~1.6.3",
         "zustand": "^5.0.13"
@@ -11252,6 +11253,55 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
+    },
+    "node_modules/react-native-webrtc": {
+      "version": "124.0.7",
+      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.7.tgz",
+      "integrity": "sha512-gnXPdbUS8IkKHq9WNaWptW/yy5s6nMyI6cNn90LXdobPVCgYSk6NA2uUGdT4c4J14BRgaFA95F+cR28tUPkMVA==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "1.5.1",
+        "debug": "4.3.4",
+        "event-target-shim": "6.0.2"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.60.0"
+      }
+    },
+    "node_modules/react-native-webrtc/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native-webrtc/node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/react-native-webrtc/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "license": "MIT"
     },
     "node_modules/react-native-worklets": {

--- a/mirror-soul/package.json
+++ b/mirror-soul/package.json
@@ -49,6 +49,7 @@
     "react-native-vision-camera": "~4.7.3",
     "react-native-vision-camera-face-detector": "~1.10.2",
     "react-native-web": "~0.21.0",
+    "react-native-webrtc": "^124.0.7",
     "react-native-worklets": "0.5.1",
     "react-native-worklets-core": "~1.6.3",
     "zustand": "^5.0.13"

--- a/mirror-soul/src/components/call/CallAIAvatar.tsx
+++ b/mirror-soul/src/components/call/CallAIAvatar.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useRef } from 'react';
+import { Animated, StyleSheet, View } from 'react-native';
+import { Colors, Radii } from '@/src/constants/theme';
+import type { CallStatus } from '@/src/hooks/useAICallFlow';
+
+interface CallAIAvatarProps {
+  callStatus: CallStatus;
+}
+
+/**
+ * AI 트윈 아바타 컴포넌트
+ * - 연결 전: 정적 원형 아바타
+ * - 통화 중: 펄스 애니메이션으로 음성 활성 표현
+ */
+export default function CallAIAvatar({ callStatus }: CallAIAvatarProps) {
+  const pulseAnim = useRef(new Animated.Value(1)).current;
+  const isConnected = callStatus === 'connected';
+
+  useEffect(() => {
+    if (isConnected) {
+      Animated.loop(
+        Animated.sequence([
+          Animated.timing(pulseAnim, { toValue: 1.15, duration: 800, useNativeDriver: true }),
+          Animated.timing(pulseAnim, { toValue: 1, duration: 800, useNativeDriver: true }),
+        ])
+      ).start();
+    } else {
+      pulseAnim.stopAnimation();
+      pulseAnim.setValue(1);
+    }
+  }, [isConnected, pulseAnim]);
+
+  return (
+    <View style={styles.container}>
+      <Animated.View style={[styles.outerRing, { transform: [{ scale: pulseAnim }] }]}>
+        <View style={styles.avatar}>
+          {/* 추후 AI 트윈 프로필 이미지로 교체 */}
+          <View style={styles.avatarInner} />
+        </View>
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  outerRing: {
+    width: 180,
+    height: 180,
+    borderRadius: 90,
+    borderWidth: 2,
+    borderColor: Colors.primary.electricCyan,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  avatar: {
+    width: 160,
+    height: 160,
+    borderRadius: 80,
+    backgroundColor: Colors.glass.slate95,
+    justifyContent: 'center',
+    alignItems: 'center',
+    overflow: 'hidden',
+  },
+  avatarInner: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    backgroundColor: Colors.glass.purple30,
+  },
+});

--- a/mirror-soul/src/components/call/CallControls.tsx
+++ b/mirror-soul/src/components/call/CallControls.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { ActivityIndicator, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Colors, Radii } from '@/src/constants/theme';
+import type { CallStatus } from '@/src/hooks/useAICallFlow';
+
+interface CallControlsProps {
+  callStatus: CallStatus;
+  onStartCall: () => void;
+  onHangUp: () => void;
+}
+
+/**
+ * 통화 제어 버튼 컴포넌트
+ * - idle / initiating / joining / inviting: 로딩 표시 (연결 중)
+ * - connected: 빨간 종료 버튼
+ * - ending: 비활성화 (종료 처리 중)
+ */
+export default function CallControls({ callStatus, onStartCall, onHangUp }: CallControlsProps) {
+  const isConnected = callStatus === 'connected';
+  const isEnding = callStatus === 'ending' || callStatus === 'ended';
+  const isIdle = callStatus === 'idle';
+  const isPending = !isIdle && !isConnected && !isEnding;
+
+  if (isIdle) {
+    return (
+      <View style={styles.container}>
+        <TouchableOpacity style={styles.startButton} onPress={onStartCall} activeOpacity={0.8}>
+          <View style={styles.startInner} />
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  if (isPending) {
+    return (
+      <View style={styles.container}>
+        <ActivityIndicator size="large" color={Colors.primary.electricCyan} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        style={[styles.endButton, isEnding && styles.disabledButton]}
+        onPress={onHangUp}
+        disabled={isEnding}
+        activeOpacity={0.8}
+      >
+        <View style={styles.endIcon} />
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    paddingBottom: 48,
+  },
+  startButton: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    backgroundColor: Colors.primary.electricCyan,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  startInner: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: Colors.primary.soulBlack,
+  },
+  endButton: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    backgroundColor: '#FF3B30',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  disabledButton: {
+    opacity: 0.5,
+  },
+  endIcon: {
+    width: 28,
+    height: 6,
+    borderRadius: Radii.sm,
+    backgroundColor: Colors.neutral.pureWhite,
+  },
+});

--- a/mirror-soul/src/components/call/CallHeader.tsx
+++ b/mirror-soul/src/components/call/CallHeader.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { Colors } from '@/src/constants/theme';
+import type { CallStatus } from '@/src/hooks/useAICallFlow';
+
+interface CallHeaderProps {
+  callStatus: CallStatus;
+}
+
+const STATUS_TEXT: Record<CallStatus, string> = {
+  idle: '연결 준비 중...',
+  initiating: '통화를 시작하는 중...',
+  joining: '서버에 연결 중...',
+  inviting: 'AI 트윈에게 연결 중...',
+  connecting: 'WebRTC 연결 중...',
+  connected: 'AI 트윈과 대화 중',
+  ending: '통화를 종료하는 중...',
+  ended: '통화가 종료되었습니다',
+};
+
+export default function CallHeader({ callStatus }: CallHeaderProps) {
+  const isConnected = callStatus === 'connected';
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.statusText, isConnected && styles.connectedText]}>
+        {STATUS_TEXT[callStatus]}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    paddingTop: 16,
+  },
+  statusText: {
+    color: Colors.neutral.lightGray,
+    fontFamily: 'Inter',
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  connectedText: {
+    color: Colors.primary.electricCyan,
+  },
+});

--- a/mirror-soul/src/components/home/grow/parts/EvolveInterviewCard.tsx
+++ b/mirror-soul/src/components/home/grow/parts/EvolveInterviewCard.tsx
@@ -2,6 +2,7 @@ import InterviewIcon from '@/assets/images/common/evlove/evlove_interview.svg';
 import TimerIcon from '@/assets/images/common/evlove/evlove_timer.svg';
 import { Colors, Radii } from '@/src/constants/theme';
 import { LinearGradient } from 'expo-linear-gradient';
+import { useRouter } from 'expo-router';
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
@@ -9,12 +10,15 @@ import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
  * 나를 알아가는 인터뷰 카드 (SRP)
  */
 export default function EvolveInterviewCard() {
+  const router = useRouter();
+
   return (
     <TouchableOpacity
       activeOpacity={0.85}
       accessibilityRole="button"
       accessibilityLabel="나를 알아가는 인터뷰 미션"
       accessibilityHint="AI와 대화하여 가치관을 공유하는 인터뷰 화면으로 이동"
+      onPress={() => router.push('/ai-call')}
     >
       <LinearGradient
         colors={[Colors.glass.purple20, Colors.glass.pink20]}

--- a/mirror-soul/src/hooks/useAICallFlow.ts
+++ b/mirror-soul/src/hooks/useAICallFlow.ts
@@ -1,0 +1,372 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Alert } from 'react-native';
+import type { MediaStream } from 'react-native-webrtc';
+import { useAuthStore } from '../store/useAuthStore';
+import { initiateCall, setCallInProgress, endCall } from '../services/callService';
+import { useWebRTCCall } from './useWebRTCCall';
+import { useCallRecording } from './useCallRecording';
+import { logger } from '../utils/logger';
+import type { SignalingMessage, CallAcceptData, AnswerData, IceData } from '../types/signaling';
+
+const WS_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL?.replace('https://', 'wss://').replace('http://', 'ws://');
+const INVITE_TIMEOUT_MS = 10000; // 10초 AI 응답 대기
+
+export type CallStatus =
+  | 'idle'        // 대기
+  | 'initiating'  // REST API 호출 중
+  | 'joining'     // WebSocket 연결 중
+  | 'inviting'    // CALL_INVITE 발송 후 AI 응답 대기
+  | 'connecting'  // WebRTC Offer/Answer/ICE 교환 중
+  | 'connected'   // 통화 중
+  | 'ending'      // 종료 처리 중 (녹음 업로드)
+  | 'ended';      // 종료 완료
+
+/**
+ * AI 트윈 음성 통화 전체 시나리오 오케스트레이션 훅 (SoC)
+ *
+ * 외부로 노출되는 인터페이스:
+ * - callStatus: 현재 통화 단계
+ * - remoteStream: AI 트윈 음성 스트림
+ * - startCall(): 통화 시작
+ * - hangUp(): 통화 종료
+ * - error: 에러 메시지
+ */
+export function useAICallFlow() {
+  const [callStatus, setCallStatus] = useState<CallStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const { userUuid } = useAuthStore();
+
+  // 세션 정보 (REST API 응답으로 채워짐)
+  const callSessionRef = useRef<{
+    callId: number;
+    roomId: string;
+    callerSignalId: string;
+    aiSignalId: string;
+  } | null>(null);
+
+  // WebSocket 단일 인스턴스 (Ref로 관리하여 re-render 시 중복 생성 방지)
+  const wsRef = useRef<WebSocket | null>(null);
+
+  // AI 응답 대기 타임아웃
+  const inviteTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const {
+    remoteStream,
+    iceConnectionState,
+    onLocalIceCandidateCb,
+    initialize: initWebRTC,
+    createOffer,
+    applyAnswer,
+    applyIceCandidate,
+    close: closeWebRTC,
+  } = useWebRTCCall();
+
+  const { startRecording, stopAndUpload } = useCallRecording();
+
+  // ─────────────────────────────────────────────
+  // WebSocket 메시지 발송 헬퍼
+  // ─────────────────────────────────────────────
+  const sendMessage = useCallback((msg: SignalingMessage) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      logger.warn('[useAICallFlow] WebSocket not open, cannot send message:', msg.type);
+      return;
+    }
+    ws.send(JSON.stringify(msg));
+    logger.debug('[useAICallFlow] Sent:', msg.type);
+  }, []);
+
+  // ─────────────────────────────────────────────
+  // WebRTC ICE → WebSocket 전달 (로컬 ICE 발생 시)
+  // ─────────────────────────────────────────────
+  useEffect(() => {
+    onLocalIceCandidateCb.current = (candidate: any) => {
+      const session = callSessionRef.current;
+      if (!session) return;
+
+      sendMessage({
+        type: 'ICE',
+        roomId: session.roomId,
+        from: session.callerSignalId,
+        to: session.aiSignalId,
+        data: {
+          callId: session.callId,
+          candidate: {
+            candidate: candidate.candidate,
+            sdpMid: candidate.sdpMid ?? '0',
+            sdpMLineIndex: candidate.sdpMLineIndex ?? 0,
+          },
+        },
+      });
+    };
+  }, [sendMessage]);
+
+  // ─────────────────────────────────────────────
+  // WebRTC 연결 성공 감지 → setCallInProgress
+  // ─────────────────────────────────────────────
+  useEffect(() => {
+    if (iceConnectionState === 'connected' && callStatus === 'connecting') {
+      const session = callSessionRef.current;
+      if (!session) return;
+
+      logger.info('[useAICallFlow] WebRTC connected! Notifying server...');
+      setCallStatus('connected');
+
+      setCallInProgress(session.callId).catch((err) => {
+        logger.error('[useAICallFlow] setCallInProgress failed:', err);
+      });
+
+      startRecording().catch((err) => {
+        logger.error('[useAICallFlow] startRecording failed:', err);
+      });
+    }
+  }, [iceConnectionState, callStatus, startRecording]);
+
+  // ─────────────────────────────────────────────
+  // WebSocket 메시지 처리
+  // ─────────────────────────────────────────────
+  const handleMessage = useCallback(async (event: WebSocketMessageEvent) => {
+    let msg: SignalingMessage;
+    try {
+      msg = JSON.parse(event.data as string);
+    } catch {
+      logger.warn('[useAICallFlow] Failed to parse WS message');
+      return;
+    }
+
+    logger.debug('[useAICallFlow] Received:', msg.type);
+    const session = callSessionRef.current;
+    if (!session) return;
+
+    switch (msg.type) {
+      case 'CALL_ACCEPT': {
+        // 타임아웃 해제
+        if (inviteTimeoutRef.current) {
+          clearTimeout(inviteTimeoutRef.current);
+          inviteTimeoutRef.current = null;
+        }
+
+        setCallStatus('connecting');
+        logger.info('[useAICallFlow] CALL_ACCEPT received. Creating offer...');
+
+        try {
+          const offer = await createOffer();
+          sendMessage({
+            type: 'OFFER',
+            roomId: session.roomId,
+            from: session.callerSignalId,
+            to: session.aiSignalId,
+            data: {
+              callId: session.callId,
+              sdp: { type: 'offer', sdp: offer.sdp ?? '' },
+            },
+          });
+        } catch (err) {
+          logger.error('[useAICallFlow] Failed to create offer:', err);
+          await _cleanup('통화 연결에 실패했습니다.');
+        }
+        break;
+      }
+
+      case 'ANSWER': {
+        const answerData = msg.data as AnswerData;
+        try {
+          await applyAnswer(answerData.sdp);
+        } catch (err) {
+          logger.error('[useAICallFlow] Failed to apply answer:', err);
+        }
+        break;
+      }
+
+      case 'ICE': {
+        const iceData = msg.data as IceData;
+        try {
+          await applyIceCandidate(iceData.candidate);
+        } catch (err) {
+          logger.error('[useAICallFlow] Failed to apply ICE candidate:', err);
+        }
+        break;
+      }
+
+      case 'CALL_REJECT':
+        await _cleanup('AI 트윈이 통화를 거절했습니다.');
+        break;
+
+      case 'CALL_END':
+        logger.info('[useAICallFlow] CALL_END received from AI');
+        await _performHangUp();
+        break;
+
+      default:
+        logger.debug('[useAICallFlow] Unhandled message type:', msg.type);
+    }
+  }, [createOffer, applyAnswer, applyIceCandidate, sendMessage]);
+
+  // ─────────────────────────────────────────────
+  // 내부 정리 함수
+  // ─────────────────────────────────────────────
+  const _cleanup = useCallback(async (errorMessage?: string) => {
+    logger.debug('[useAICallFlow] Cleaning up...');
+
+    if (inviteTimeoutRef.current) {
+      clearTimeout(inviteTimeoutRef.current);
+      inviteTimeoutRef.current = null;
+    }
+
+    const ws = wsRef.current;
+    if (ws) {
+      ws.onmessage = null;
+      ws.onclose = null;
+      ws.onerror = null;
+      if (ws.readyState === WebSocket.OPEN) ws.close();
+      wsRef.current = null;
+    }
+
+    closeWebRTC();
+    callSessionRef.current = null;
+
+    if (errorMessage) {
+      setError(errorMessage);
+      Alert.alert('통화 오류', errorMessage);
+    }
+
+    setCallStatus('ended');
+  }, [closeWebRTC]);
+
+  // ─────────────────────────────────────────────
+  // 통화 종료 내부 처리 (녹음 업로드 포함)
+  // ─────────────────────────────────────────────
+  const _performHangUp = useCallback(async () => {
+    const session = callSessionRef.current;
+    if (!session) return;
+
+    setCallStatus('ending');
+    logger.info('[useAICallFlow] Hanging up...');
+
+    // 1. WebSocket CALL_END 발송
+    sendMessage({
+      type: 'CALL_END',
+      roomId: session.roomId,
+      from: session.callerSignalId,
+      to: session.aiSignalId,
+      data: { callId: session.callId },
+    });
+
+    // 2. 녹음 중단 및 S3 업로드
+    const recordingUrl = await stopAndUpload(userUuid ?? '');
+
+    // 3. REST API 종료 알림
+    try {
+      await endCall(session.callId, recordingUrl);
+    } catch (err) {
+      logger.error('[useAICallFlow] endCall REST failed:', err);
+    }
+
+    // 4. 정리
+    await _cleanup();
+  }, [sendMessage, stopAndUpload, userUuid, endCall, _cleanup]);
+
+  // ─────────────────────────────────────────────
+  // 통화 시작 (공개 API)
+  // ─────────────────────────────────────────────
+  const startCall = useCallback(async () => {
+    if (!userUuid) {
+      Alert.alert('오류', '사용자 정보를 찾을 수 없습니다.');
+      return;
+    }
+
+    setError(null);
+    setCallStatus('initiating');
+    logger.info('[useAICallFlow] Starting call...');
+
+    try {
+      // 1. REST API: 방 생성
+      const response = await initiateCall(userUuid, {
+        callerUserUuid: userUuid,
+        mediaType: 'VOICE',
+      });
+
+      if (!response.isSuccess) throw new Error(response.message);
+
+      const { callId, roomId, callerSignalId, aiSignalId } = response.result;
+      callSessionRef.current = { callId, roomId, callerSignalId, aiSignalId };
+
+      // 2. WebRTC 초기화 (마이크 스트림 획득)
+      await initWebRTC();
+
+      // 3. WebSocket 연결
+      setCallStatus('joining');
+      const ws = new WebSocket(`${WS_BASE_URL}/ws/signaling`);
+      wsRef.current = ws;
+
+      ws.onerror = (e) => {
+        logger.error('[useAICallFlow] WebSocket error:', e);
+        _cleanup('시그널링 서버 연결에 실패했습니다.');
+      };
+
+      ws.onclose = () => {
+        logger.debug('[useAICallFlow] WebSocket closed');
+      };
+
+      ws.onmessage = handleMessage;
+
+      ws.onopen = () => {
+        logger.info('[useAICallFlow] WebSocket connected. Sending JOIN...');
+
+        // 4. JOIN 발송
+        ws.send(JSON.stringify({
+          type: 'JOIN',
+          roomId,
+          from: callerSignalId,
+          to: 'server',
+          data: null,
+        }));
+
+        // 5. CALL_INVITE 발송
+        setCallStatus('inviting');
+        ws.send(JSON.stringify({
+          type: 'CALL_INVITE',
+          roomId,
+          from: callerSignalId,
+          to: aiSignalId,
+          data: { callId, cloneUserUuid: userUuid, mediaType: 'VOICE' },
+        }));
+
+        // 6. 10초 타임아웃
+        inviteTimeoutRef.current = setTimeout(() => {
+          logger.warn('[useAICallFlow] CALL_INVITE timeout after 10s');
+          _cleanup('AI 트윈이 응답하지 않습니다. 잠시 후 다시 시도해주세요.');
+        }, INVITE_TIMEOUT_MS);
+      };
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : '통화를 시작할 수 없습니다.';
+      logger.error('[useAICallFlow] startCall failed:', err);
+      setError(message);
+      setCallStatus('idle');
+      Alert.alert('통화 오류', message);
+    }
+  }, [userUuid, initWebRTC, handleMessage, _cleanup]);
+
+  // ─────────────────────────────────────────────
+  // 통화 종료 (공개 API)
+  // ─────────────────────────────────────────────
+  const hangUp = useCallback(async () => {
+    await _performHangUp();
+  }, [_performHangUp]);
+
+  // 언마운트 시 자동 정리
+  useEffect(() => {
+    return () => {
+      _cleanup();
+    };
+  }, [_cleanup]);
+
+  return {
+    callStatus,
+    remoteStream: remoteStream as MediaStream | null,
+    startCall,
+    hangUp,
+    error,
+  };
+}

--- a/mirror-soul/src/hooks/useAICallFlow.ts
+++ b/mirror-soul/src/hooks/useAICallFlow.ts
@@ -140,6 +140,25 @@ export function useAICallFlow() {
     if (!session) return;
 
     switch (msg.type) {
+      case 'JOINED': {
+        logger.info('[useAICallFlow] JOINED received. Sending CALL_INVITE...');
+        setCallStatus('inviting');
+
+        sendMessage({
+          type: 'CALL_INVITE',
+          roomId: session.roomId,
+          from: session.callerSignalId,
+          to: session.aiSignalId,
+          data: { callId: session.callId, cloneUserUuid: userUuid, mediaType: 'VOICE' },
+        });
+
+        inviteTimeoutRef.current = setTimeout(() => {
+          logger.warn('[useAICallFlow] CALL_INVITE timeout after 10s');
+          _cleanup('AI 트윈이 응답하지 않습니다. 잠시 후 다시 시도해주세요.');
+        }, INVITE_TIMEOUT_MS);
+        break;
+      }
+
       case 'CALL_ACCEPT': {
         // 타임아웃 해제
         if (inviteTimeoutRef.current) {
@@ -201,7 +220,7 @@ export function useAICallFlow() {
       default:
         logger.debug('[useAICallFlow] Unhandled message type:', msg.type);
     }
-  }, [createOffer, applyAnswer, applyIceCandidate, sendMessage]);
+  }, [createOffer, applyAnswer, applyIceCandidate, sendMessage, userUuid]);
 
   // ─────────────────────────────────────────────
   // 내부 정리 함수
@@ -322,22 +341,6 @@ export function useAICallFlow() {
           to: 'server',
           data: null,
         }));
-
-        // 5. CALL_INVITE 발송
-        setCallStatus('inviting');
-        ws.send(JSON.stringify({
-          type: 'CALL_INVITE',
-          roomId,
-          from: callerSignalId,
-          to: aiSignalId,
-          data: { callId, cloneUserUuid: userUuid, mediaType: 'VOICE' },
-        }));
-
-        // 6. 10초 타임아웃
-        inviteTimeoutRef.current = setTimeout(() => {
-          logger.warn('[useAICallFlow] CALL_INVITE timeout after 10s');
-          _cleanup('AI 트윈이 응답하지 않습니다. 잠시 후 다시 시도해주세요.');
-        }, INVITE_TIMEOUT_MS);
       };
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : '통화를 시작할 수 없습니다.';

--- a/mirror-soul/src/hooks/useAICallFlow.ts
+++ b/mirror-soul/src/hooks/useAICallFlow.ts
@@ -151,7 +151,7 @@ export function useAICallFlow() {
           roomId: session.roomId,
           from: session.callerSignalId,
           to: session.aiSignalId,
-          data: { callId: session.callId, cloneUserUuid: userUuid, mediaType: 'VOICE' },
+          data: { callId: session.callId, cloneUserUuid: userUuid ?? '', mediaType: 'VOICE' },
         });
 
         inviteTimeoutRef.current = setTimeout(() => {

--- a/mirror-soul/src/hooks/useAICallFlow.ts
+++ b/mirror-soul/src/hooks/useAICallFlow.ts
@@ -6,7 +6,7 @@ import { initiateCall, setCallInProgress, endCall } from '../services/callServic
 import { useWebRTCCall } from './useWebRTCCall';
 import { useCallRecording } from './useCallRecording';
 import { logger } from '../utils/logger';
-import type { SignalingMessage, CallAcceptData, AnswerData, IceData } from '../types/signaling';
+import type { SignalingMessage, CallAcceptData, AnswerData, IceData, OfferData } from '../types/signaling';
 
 const WS_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL?.replace('https://', 'wss://').replace('http://', 'ws://');
 const INVITE_TIMEOUT_MS = 10000; // 10초 AI 응답 대기
@@ -57,7 +57,9 @@ export function useAICallFlow() {
     onLocalIceCandidateCb,
     initialize: initWebRTC,
     createOffer,
+    createAnswer,
     applyAnswer,
+    applyOffer,
     applyIceCandidate,
     close: closeWebRTC,
   } = useWebRTCCall();
@@ -188,6 +190,29 @@ export function useAICallFlow() {
         break;
       }
 
+      case 'OFFER': {
+        // AI 주도 재협상: 수신한 메시지의 from/to를 뒤집어서 ANSWER 발송 (백엔드 컨벤션)
+        const offerData = msg.data as OfferData;
+        try {
+          logger.info('[useAICallFlow] OFFER received from AI. Applying and creating answer...');
+          await applyOffer(offerData.sdp);
+          const answer = await createAnswer();
+          sendMessage({
+            type: 'ANSWER',
+            roomId: msg.roomId,
+            from: msg.to,
+            to: msg.from,
+            data: {
+              callId: offerData.callId,
+              sdp: { type: 'answer', sdp: answer.sdp ?? '' },
+            },
+          });
+        } catch (err) {
+          logger.error('[useAICallFlow] Failed to handle AI OFFER:', err);
+        }
+        break;
+      }
+
       case 'ANSWER': {
         const answerData = msg.data as AnswerData;
         try {
@@ -220,7 +245,7 @@ export function useAICallFlow() {
       default:
         logger.debug('[useAICallFlow] Unhandled message type:', msg.type);
     }
-  }, [createOffer, applyAnswer, applyIceCandidate, sendMessage, userUuid]);
+  }, [createOffer, createAnswer, applyAnswer, applyOffer, applyIceCandidate, sendMessage, userUuid]);
 
   // ─────────────────────────────────────────────
   // 내부 정리 함수

--- a/mirror-soul/src/hooks/useAICallFlow.ts
+++ b/mirror-soul/src/hooks/useAICallFlow.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Alert } from 'react-native';
 import type { MediaStream } from 'react-native-webrtc';
+import { AudioModule, setAudioModeAsync } from 'expo-audio';
 import { useAuthStore } from '../store/useAuthStore';
 import { initiateCall, setCallInProgress, endCall } from '../services/callService';
 import { useWebRTCCall } from './useWebRTCCall';
@@ -297,8 +298,16 @@ export function useAICallFlow() {
       data: { callId: session.callId },
     });
 
-    // 2. 녹음 중단 및 S3 업로드
+    // 2. 녹음 중단 및 S3 업로드 (내 목소리 → AI 학습/분석용)
     const recordingUrl = await stopAndUpload(userUuid ?? '');
+
+    // TODO: 통화 기록(대화 내용) 저장
+    // 나와 AI 서버가 주고받은 대화 내용을 callId 기준으로 저장해야 합니다.
+    // 구현 방향 (백엔드 협의 필요):
+    //   - 방법 A (권장): 백엔드가 callId별 AI 응답 텍스트 + 사용자 음성 STT 결과를 저장
+    //                    → GET /calls/{callId}/transcript 로 조회
+    //   - 방법 B: 클라이언트에서 통화 중 실시간 STT(useSTT)로 수집한 텍스트를 endCall 시 전송
+    // 현재는 recordingUrl(S3 음성 파일)만 전달하며, 텍스트 기록은 추후 추가 예정
 
     // 3. REST API 종료 알림
     try {
@@ -325,6 +334,28 @@ export function useAICallFlow() {
     logger.info('[useAICallFlow] Starting call...');
 
     try {
+      // ─── 전제조건 1: 마이크 권한 확인/요청 ───
+      // 통화 시작 전에 권한을 미리 요청합니다.
+      // 권한이 없으면 WebRTC 초기화 자체가 실패하므로 여기서 조기 차단합니다.
+      const { granted } = await AudioModule.requestRecordingPermissionsAsync();
+      if (!granted) {
+        logger.warn('[useAICallFlow] Microphone permission denied');
+        Alert.alert(
+          '마이크 권한 필요',
+          '통화를 시작하려면 마이크 접근 권한이 필요합니다. 설정에서 권한을 허용해주세요.'
+        );
+        setCallStatus('idle');
+        return;
+      }
+      logger.debug('[useAICallFlow] Microphone permission granted');
+
+      // ─── 전제조건 2: iOS 오디오 세션을 녹음 가능 모드로 사전 설정 ───
+      // WebRTC(getUserMedia)와 expo-audio가 같은 마이크를 공유하려면
+      // iOS AVAudioSession이 처음부터 .playAndRecord 모드여야 합니다.
+      // initWebRTC() 호출 전에 설정해야 충돌이 발생하지 않습니다.
+      await setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true });
+      logger.debug('[useAICallFlow] Audio mode configured for recording');
+
       // 1. REST API: 방 생성
       const response = await initiateCall(userUuid, {
         callerUserUuid: userUuid,

--- a/mirror-soul/src/hooks/useCallRecording.ts
+++ b/mirror-soul/src/hooks/useCallRecording.ts
@@ -1,0 +1,84 @@
+import { useRef } from 'react';
+import { Platform } from 'react-native';
+import { useAudioRecorder, RecordingPresets } from 'expo-audio';
+import { getPresignedUrl } from '../services/fileService';
+import { uploadFileToS3 } from '../services/s3Service';
+import { logger } from '../utils/logger';
+
+/**
+ * 통화 중 내 음성 녹음 및 S3 업로드 담당 훅 (SoC)
+ *
+ * - startRecording: WebRTC 연결 성공 시 자동 호출
+ * - stopAndUpload: 통화 종료 시 호출 → S3 fileUrl 반환
+ *
+ * NOTE: directory는 백엔드가 'call-recordings'를 추가하기 전까지
+ *       임시로 'interviews'를 사용합니다.
+ */
+export function useCallRecording() {
+  const recorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
+  const isRecordingRef = useRef(false);
+
+  const startRecording = async () => {
+    try {
+      await recorder.prepareToRecordAsync();
+      recorder.record();
+      isRecordingRef.current = true;
+      logger.debug('[useCallRecording] Recording started');
+    } catch (err) {
+      logger.error('[useCallRecording] Failed to start recording:', err);
+      throw err;
+    }
+  };
+
+  const stopAndUpload = async (userUuid: string): Promise<string> => {
+    if (!isRecordingRef.current) {
+      logger.warn('[useCallRecording] stopAndUpload called but not recording');
+      return '';
+    }
+
+    try {
+      // 1. 녹음 중단 및 URI 획득
+      await recorder.stop();
+      isRecordingRef.current = false;
+      const uri = recorder.uri;
+
+      if (!uri) {
+        logger.warn('[useCallRecording] Recording URI is null after stop');
+        return '';
+      }
+
+      logger.debug('[useCallRecording] Recording stopped, uploading to S3...');
+
+      // 2. OS별 파일 설정
+      const extension = Platform.OS === 'ios' ? 'wav' : 'm4a';
+      const contentType = Platform.OS === 'ios' ? 'audio/wav' : 'audio/mp4';
+      const fileName = `call-recording.${extension}`;
+
+      // 3. Presigned URL 발급 (임시: 'interviews' 디렉토리 사용)
+      const presignedResponse = await getPresignedUrl({
+        userUuid,
+        fileName,
+        contentType,
+        directory: 'interviews', // TODO: 백엔드 추가 후 'call-recordings'로 변경
+      });
+
+      if (!presignedResponse.isSuccess) {
+        throw new Error(presignedResponse.message || '업로드 주소 발급에 실패했습니다.');
+      }
+
+      const { presignedUrl, fileUrl } = presignedResponse.result;
+
+      // 4. S3 직접 업로드
+      await uploadFileToS3(presignedUrl, uri, contentType);
+      logger.info('[useCallRecording] Recording uploaded to S3:', fileUrl);
+
+      return fileUrl;
+    } catch (err) {
+      logger.error('[useCallRecording] stopAndUpload failed:', err);
+      // 업로드 실패 시 빈 URL 반환 (통화 종료 자체는 막지 않음)
+      return '';
+    }
+  };
+
+  return { startRecording, stopAndUpload };
+}

--- a/mirror-soul/src/hooks/useCallRecording.ts
+++ b/mirror-soul/src/hooks/useCallRecording.ts
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 import { Platform } from 'react-native';
-import { useAudioRecorder, RecordingPresets } from 'expo-audio';
+import { useAudioRecorder, RecordingPresets, AudioModule, setAudioModeAsync } from 'expo-audio';
 import { getPresignedUrl } from '../services/fileService';
 import { uploadFileToS3 } from '../services/s3Service';
 import { logger } from '../utils/logger';
@@ -20,6 +20,15 @@ export function useCallRecording() {
 
   const startRecording = async () => {
     try {
+      // 방어적 권한 확인: 이 훅이 독립적으로 재사용될 때도 안전하게 동작하도록 보장
+      const { granted } = await AudioModule.getRecordingPermissionsAsync();
+      if (!granted) {
+        throw new Error('마이크 녹음 권한이 없습니다. 통화 시작 전 권한을 요청해주세요.');
+      }
+
+      // iOS AVAudioSession을 녹음 가능 모드로 설정 (안전망: useAICallFlow에서 선행 설정되지만 중복 호출은 무해함)
+      await setAudioModeAsync({ allowsRecording: true, playsInSilentMode: true });
+
       await recorder.prepareToRecordAsync();
       recorder.record();
       isRecordingRef.current = true;

--- a/mirror-soul/src/hooks/useWebRTCCall.ts
+++ b/mirror-soul/src/hooks/useWebRTCCall.ts
@@ -28,6 +28,9 @@ export function useWebRTCCall() {
   // ICE 후보 발생 시 시그널링 서버로 전달하기 위한 콜백 Ref
   const onLocalIceCandidateCb = useRef<((candidate: RTCIceCandidateType) => void) | null>(null);
 
+  // Remote Description 등록 전 도착한 ICE 후보 임시 버퍼
+  const pendingIceCandidatesRef = useRef<RTCIceCandidateType[]>([]);
+
   /** PeerConnection 초기화 및 로컬 마이크 스트림 획득 */
   const initialize = useCallback(async () => {
     logger.debug('[useWebRTCCall] Initializing PeerConnection...');
@@ -71,6 +74,17 @@ export function useWebRTCCall() {
     }
   }, []);
 
+  /** 버퍼링된 ICE 후보를 일괄 적용하는 내부 헬퍼 */
+  const flushPendingIceCandidates = useCallback(async (pc: RTCPeerConnection) => {
+    const pending = pendingIceCandidatesRef.current;
+    if (pending.length === 0) return;
+    pendingIceCandidatesRef.current = [];
+    for (const candidate of pending) {
+      await pc.addIceCandidate(new RTCIceCandidate(candidate));
+    }
+    logger.debug('[useWebRTCCall] Flushed pending ICE candidates:', pending.length);
+  }, []);
+
   /** SDP Offer 생성 */
   const createOffer = useCallback(async (): Promise<RTCSessionDescriptionType> => {
     const pc = pcRef.current;
@@ -82,6 +96,16 @@ export function useWebRTCCall() {
     return offer as RTCSessionDescriptionType;
   }, []);
 
+  /** SDP Answer 생성 (AI의 Offer에 대한 응답 시) */
+  const createAnswer = useCallback(async (): Promise<RTCSessionDescriptionType> => {
+    const pc = pcRef.current;
+    if (!pc) throw new Error('PeerConnection이 초기화되지 않았습니다.');
+    const answer = await pc.createAnswer();
+    await pc.setLocalDescription(new RTCSessionDescription(answer));
+    logger.debug('[useWebRTCCall] Answer created and set as local description');
+    return answer as RTCSessionDescriptionType;
+  }, []);
+
   /** AI 서버의 SDP Answer 적용 */
   const applyAnswer = useCallback(async (sdp: RTCSessionDescriptionType): Promise<void> => {
     const pc = pcRef.current;
@@ -89,13 +113,28 @@ export function useWebRTCCall() {
 
     await pc.setRemoteDescription(new RTCSessionDescription(sdp));
     logger.debug('[useWebRTCCall] Remote answer applied');
-  }, []);
+    await flushPendingIceCandidates(pc);
+  }, [flushPendingIceCandidates]);
 
-  /** AI 서버의 ICE 후보 적용 */
+  /** AI 서버의 SDP Offer 적용 (재협상 시) */
+  const applyOffer = useCallback(async (sdp: RTCSessionDescriptionType): Promise<void> => {
+    const pc = pcRef.current;
+    if (!pc) throw new Error('PeerConnection이 초기화되지 않았습니다.');
+    await pc.setRemoteDescription(new RTCSessionDescription(sdp));
+    logger.debug('[useWebRTCCall] Remote offer applied');
+    await flushPendingIceCandidates(pc);
+  }, [flushPendingIceCandidates]);
+
+  /** AI 서버의 ICE 후보 적용 (Remote Description 미등록 시 버퍼링) */
   const applyIceCandidate = useCallback(async (candidate: RTCIceCandidateType): Promise<void> => {
     const pc = pcRef.current;
     if (!pc) throw new Error('PeerConnection이 초기화되지 않았습니다.');
 
+    if (!pc.remoteDescription) {
+      pendingIceCandidatesRef.current.push(candidate);
+      logger.debug('[useWebRTCCall] Buffered ICE candidate (no remote description yet)');
+      return;
+    }
     await pc.addIceCandidate(new RTCIceCandidate(candidate));
     logger.debug('[useWebRTCCall] Remote ICE candidate applied');
   }, []);
@@ -105,6 +144,7 @@ export function useWebRTCCall() {
     const pc = pcRef.current;
     if (!pc) return;
 
+    pendingIceCandidatesRef.current = [];
     pc.getSenders().forEach((sender: any) => {
       sender.track?.stop();
     });
@@ -128,7 +168,9 @@ export function useWebRTCCall() {
     onLocalIceCandidateCb,
     initialize,
     createOffer,
+    createAnswer,
     applyAnswer,
+    applyOffer,
     applyIceCandidate,
     close,
   };

--- a/mirror-soul/src/hooks/useWebRTCCall.ts
+++ b/mirror-soul/src/hooks/useWebRTCCall.ts
@@ -6,10 +6,6 @@ import {
   RTCSessionDescription,
   mediaDevices,
 } from 'react-native-webrtc';
-import type {
-  RTCIceCandidateType,
-  RTCSessionDescriptionType,
-} from 'react-native-webrtc';
 import { logger } from '../utils/logger';
 
 const ICE_SERVERS = [{ urls: 'stun:stun.l.google.com:19302' }];
@@ -26,10 +22,10 @@ export function useWebRTCCall() {
   const [iceConnectionState, setIceConnectionState] = useState<string>('new');
 
   // ICE 후보 발생 시 시그널링 서버로 전달하기 위한 콜백 Ref
-  const onLocalIceCandidateCb = useRef<((candidate: RTCIceCandidateType) => void) | null>(null);
+  const onLocalIceCandidateCb = useRef<((candidate: RTCIceCandidate) => void) | null>(null);
 
   // Remote Description 등록 전 도착한 ICE 후보 임시 버퍼
-  const pendingIceCandidatesRef = useRef<RTCIceCandidateType[]>([]);
+  const pendingIceCandidatesRef = useRef<RTCIceCandidate[]>([]);
 
   /** PeerConnection 초기화 및 로컬 마이크 스트림 획득 */
   const initialize = useCallback(async () => {
@@ -39,27 +35,27 @@ export function useWebRTCCall() {
     pcRef.current = pc;
 
     // 원격 오디오 스트림 수신
-    pc.ontrack = (event: any) => {
+    pc.addEventListener('track', (event: any) => {
       logger.debug('[useWebRTCCall] Remote track received');
       if (event.streams?.[0]) {
         setRemoteStream(event.streams[0]);
       }
-    };
+    });
 
     // 로컬 ICE 후보 발생 시 콜백으로 전달
-    pc.onicecandidate = (event: any) => {
+    pc.addEventListener('icecandidate', (event: any) => {
       if (event.candidate) {
         logger.debug('[useWebRTCCall] Local ICE candidate generated');
         onLocalIceCandidateCb.current?.(event.candidate);
       }
-    };
+    });
 
     // 연결 상태 변화 감지
-    pc.oniceconnectionstatechange = () => {
+    pc.addEventListener('iceconnectionstatechange', () => {
       const state = pc.iceConnectionState;
       logger.debug('[useWebRTCCall] ICE connection state:', state);
       setIceConnectionState(state);
-    };
+    });
 
     // 로컬 마이크 스트림 획득 후 PeerConnection에 추가
     try {
@@ -75,7 +71,7 @@ export function useWebRTCCall() {
   }, []);
 
   /** 버퍼링된 ICE 후보를 일괄 적용하는 내부 헬퍼 */
-  const flushPendingIceCandidates = useCallback(async (pc: RTCPeerConnection) => {
+  const flushPendingIceCandidates = useCallback(async (pc: any) => {
     const pending = pendingIceCandidatesRef.current;
     if (pending.length === 0) return;
     pendingIceCandidatesRef.current = [];
@@ -86,28 +82,28 @@ export function useWebRTCCall() {
   }, []);
 
   /** SDP Offer 생성 */
-  const createOffer = useCallback(async (): Promise<RTCSessionDescriptionType> => {
+  const createOffer = useCallback(async (): Promise<any> => {
     const pc = pcRef.current;
     if (!pc) throw new Error('PeerConnection이 초기화되지 않았습니다.');
 
     const offer = await pc.createOffer({});
     await pc.setLocalDescription(new RTCSessionDescription(offer));
     logger.debug('[useWebRTCCall] Offer created and set as local description');
-    return offer as RTCSessionDescriptionType;
+    return offer;
   }, []);
 
   /** SDP Answer 생성 (AI의 Offer에 대한 응답 시) */
-  const createAnswer = useCallback(async (): Promise<RTCSessionDescriptionType> => {
+  const createAnswer = useCallback(async (): Promise<any> => {
     const pc = pcRef.current;
     if (!pc) throw new Error('PeerConnection이 초기화되지 않았습니다.');
     const answer = await pc.createAnswer();
     await pc.setLocalDescription(new RTCSessionDescription(answer));
     logger.debug('[useWebRTCCall] Answer created and set as local description');
-    return answer as RTCSessionDescriptionType;
+    return answer;
   }, []);
 
   /** AI 서버의 SDP Answer 적용 */
-  const applyAnswer = useCallback(async (sdp: RTCSessionDescriptionType): Promise<void> => {
+  const applyAnswer = useCallback(async (sdp: any): Promise<void> => {
     const pc = pcRef.current;
     if (!pc) throw new Error('PeerConnection이 초기화되지 않았습니다.');
 
@@ -117,7 +113,7 @@ export function useWebRTCCall() {
   }, [flushPendingIceCandidates]);
 
   /** AI 서버의 SDP Offer 적용 (재협상 시) */
-  const applyOffer = useCallback(async (sdp: RTCSessionDescriptionType): Promise<void> => {
+  const applyOffer = useCallback(async (sdp: any): Promise<void> => {
     const pc = pcRef.current;
     if (!pc) throw new Error('PeerConnection이 초기화되지 않았습니다.');
     await pc.setRemoteDescription(new RTCSessionDescription(sdp));
@@ -126,7 +122,7 @@ export function useWebRTCCall() {
   }, [flushPendingIceCandidates]);
 
   /** AI 서버의 ICE 후보 적용 (Remote Description 미등록 시 버퍼링) */
-  const applyIceCandidate = useCallback(async (candidate: RTCIceCandidateType): Promise<void> => {
+  const applyIceCandidate = useCallback(async (candidate: RTCIceCandidate): Promise<void> => {
     const pc = pcRef.current;
     if (!pc) throw new Error('PeerConnection이 초기화되지 않았습니다.');
 

--- a/mirror-soul/src/hooks/useWebRTCCall.ts
+++ b/mirror-soul/src/hooks/useWebRTCCall.ts
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  MediaStream,
+  RTCIceCandidate,
+  RTCPeerConnection,
+  RTCSessionDescription,
+  mediaDevices,
+} from 'react-native-webrtc';
+import type {
+  RTCIceCandidateType,
+  RTCSessionDescriptionType,
+} from 'react-native-webrtc';
+import { logger } from '../utils/logger';
+
+const ICE_SERVERS = [{ urls: 'stun:stun.l.google.com:19302' }];
+
+/**
+ * WebRTC PeerConnection 생명주기를 관리하는 훅 (SoC)
+ *
+ * 역할: RTCPeerConnection 생성, 로컬 마이크 스트림, 원격 오디오 스트림 수신
+ * 시그널링 로직은 useAICallFlow에서 담당합니다.
+ */
+export function useWebRTCCall() {
+  const pcRef = useRef<RTCPeerConnection | null>(null);
+  const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null);
+  const [iceConnectionState, setIceConnectionState] = useState<string>('new');
+
+  // ICE 후보 발생 시 시그널링 서버로 전달하기 위한 콜백 Ref
+  const onLocalIceCandidateCb = useRef<((candidate: RTCIceCandidateType) => void) | null>(null);
+
+  /** PeerConnection 초기화 및 로컬 마이크 스트림 획득 */
+  const initialize = useCallback(async () => {
+    logger.debug('[useWebRTCCall] Initializing PeerConnection...');
+
+    const pc = new RTCPeerConnection({ iceServers: ICE_SERVERS });
+    pcRef.current = pc;
+
+    // 원격 오디오 스트림 수신
+    pc.ontrack = (event: any) => {
+      logger.debug('[useWebRTCCall] Remote track received');
+      if (event.streams?.[0]) {
+        setRemoteStream(event.streams[0]);
+      }
+    };
+
+    // 로컬 ICE 후보 발생 시 콜백으로 전달
+    pc.onicecandidate = (event: any) => {
+      if (event.candidate) {
+        logger.debug('[useWebRTCCall] Local ICE candidate generated');
+        onLocalIceCandidateCb.current?.(event.candidate);
+      }
+    };
+
+    // 연결 상태 변화 감지
+    pc.oniceconnectionstatechange = () => {
+      const state = pc.iceConnectionState;
+      logger.debug('[useWebRTCCall] ICE connection state:', state);
+      setIceConnectionState(state);
+    };
+
+    // 로컬 마이크 스트림 획득 후 PeerConnection에 추가
+    try {
+      const stream = await mediaDevices.getUserMedia({ audio: true, video: false });
+      stream.getTracks().forEach((track: any) => {
+        pc.addTrack(track, stream);
+      });
+      logger.debug('[useWebRTCCall] Local audio track added');
+    } catch (err) {
+      logger.error('[useWebRTCCall] Failed to get microphone stream:', err);
+      throw err;
+    }
+  }, []);
+
+  /** SDP Offer 생성 */
+  const createOffer = useCallback(async (): Promise<RTCSessionDescriptionType> => {
+    const pc = pcRef.current;
+    if (!pc) throw new Error('PeerConnection이 초기화되지 않았습니다.');
+
+    const offer = await pc.createOffer({});
+    await pc.setLocalDescription(new RTCSessionDescription(offer));
+    logger.debug('[useWebRTCCall] Offer created and set as local description');
+    return offer as RTCSessionDescriptionType;
+  }, []);
+
+  /** AI 서버의 SDP Answer 적용 */
+  const applyAnswer = useCallback(async (sdp: RTCSessionDescriptionType): Promise<void> => {
+    const pc = pcRef.current;
+    if (!pc) throw new Error('PeerConnection이 초기화되지 않았습니다.');
+
+    await pc.setRemoteDescription(new RTCSessionDescription(sdp));
+    logger.debug('[useWebRTCCall] Remote answer applied');
+  }, []);
+
+  /** AI 서버의 ICE 후보 적용 */
+  const applyIceCandidate = useCallback(async (candidate: RTCIceCandidateType): Promise<void> => {
+    const pc = pcRef.current;
+    if (!pc) throw new Error('PeerConnection이 초기화되지 않았습니다.');
+
+    await pc.addIceCandidate(new RTCIceCandidate(candidate));
+    logger.debug('[useWebRTCCall] Remote ICE candidate applied');
+  }, []);
+
+  /** 정리: PeerConnection 및 트랙 해제 */
+  const close = useCallback(() => {
+    const pc = pcRef.current;
+    if (!pc) return;
+
+    pc.getSenders().forEach((sender: any) => {
+      sender.track?.stop();
+    });
+    pc.close();
+    pcRef.current = null;
+    setRemoteStream(null);
+    setIceConnectionState('closed');
+    logger.debug('[useWebRTCCall] PeerConnection closed and cleaned up');
+  }, []);
+
+  // 언마운트 시 자동 정리 (메모리 누수 방지)
+  useEffect(() => {
+    return () => {
+      close();
+    };
+  }, [close]);
+
+  return {
+    remoteStream,
+    iceConnectionState,
+    onLocalIceCandidateCb,
+    initialize,
+    createOffer,
+    applyAnswer,
+    applyIceCandidate,
+    close,
+  };
+}

--- a/mirror-soul/src/services/callService.ts
+++ b/mirror-soul/src/services/callService.ts
@@ -1,0 +1,70 @@
+import apiClient from './apiClient';
+import {
+  EndCallRequest,
+  EndCallResponse,
+  InitiateCallRequest,
+  InitiateCallResponse,
+  InProgressResponse,
+} from '../types/api/call';
+import { logger } from '../utils/logger';
+
+/**
+ * 통화(Call) 도메인 API 서비스 (SoC)
+ */
+
+/** 클론에게 음성 통화 걸기 */
+export const initiateCall = async (
+  cloneUserUuid: string,
+  data: InitiateCallRequest
+): Promise<InitiateCallResponse> => {
+  const url = `/calls/clones/${cloneUserUuid}`;
+  logger.debug('initiateCall:', { url, data });
+  try {
+    const response = await apiClient.post<InitiateCallResponse>(url, data);
+    logger.info('initiateCall SUCCESS:', response.data);
+    return response.data;
+  } catch (error: unknown) {
+    logger.error('initiateCall ERROR:', {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+};
+
+/** 통화 연결 완료 처리 */
+export const setCallInProgress = async (
+  callId: number
+): Promise<InProgressResponse> => {
+  const url = `/calls/${callId}/in-progress`;
+  logger.debug('setCallInProgress:', { callId });
+  try {
+    const response = await apiClient.patch<InProgressResponse>(url);
+    logger.info('setCallInProgress SUCCESS');
+    return response.data;
+  } catch (error: unknown) {
+    logger.error('setCallInProgress ERROR:', {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+};
+
+/** 통화 종료 */
+export const endCall = async (
+  callId: number,
+  recordingUrl: string
+): Promise<EndCallResponse> => {
+  const url = `/calls/${callId}/end`;
+  logger.debug('endCall:', { callId });
+  const body: EndCallRequest = { recordingUrl };
+  try {
+    const response = await apiClient.post<EndCallResponse>(url, body);
+    logger.info('endCall SUCCESS:', response.data);
+    return response.data;
+  } catch (error: unknown) {
+    logger.error('endCall ERROR:', {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+};

--- a/mirror-soul/src/types/api/call.ts
+++ b/mirror-soul/src/types/api/call.ts
@@ -1,0 +1,43 @@
+import { ApiResponse } from './common';
+
+/**
+ * 통화(Call) 도메인 API 타입 정의
+ */
+
+// ─────────────────────────────────────────────
+// POST /calls/clones/{clone-user-uuid}
+// ─────────────────────────────────────────────
+export interface InitiateCallRequest {
+  callerUserUuid: string;
+  mediaType: 'VOICE';
+}
+
+export interface InitiateCallResult {
+  callId: number;
+  roomId: string;
+  mediaType: 'VOICE';
+  status: string;
+  callerSignalId: string;
+  aiSignalId: string;
+  signalingUrl: string;
+}
+
+export type InitiateCallResponse = ApiResponse<InitiateCallResult>;
+
+// ─────────────────────────────────────────────
+// PATCH /calls/{call-id}/in-progress
+// ─────────────────────────────────────────────
+export type InProgressResponse = ApiResponse<string>;
+
+// ─────────────────────────────────────────────
+// POST /calls/{call-id}/end
+// ─────────────────────────────────────────────
+export interface EndCallRequest {
+  recordingUrl: string;
+}
+
+export interface EndCallResult {
+  recordingUrl: string;
+}
+
+export type EndCallResponse = ApiResponse<EndCallResult>;

--- a/mirror-soul/src/types/api/file.ts
+++ b/mirror-soul/src/types/api/file.ts
@@ -4,7 +4,7 @@ import { ApiResponse } from './common';
  * 파일 도메인 API 타입 정의
  */
 
-export type FileType = 'interviews' | 'face-videos' | 'job-certifications';
+export type FileType = 'interviews' | 'face-videos' | 'job-certifications' | 'call-recordings';
 
 // ─────────────────────────────────────────────
 // POST /files/presigned-url

--- a/mirror-soul/src/types/signaling.ts
+++ b/mirror-soul/src/types/signaling.ts
@@ -1,0 +1,79 @@
+/**
+ * WebSocket 시그널링 메시지 타입 정의
+ *
+ * 이 파일의 data 필드 구조는 백엔드에 전달하여 서버측 검증 로직에 사용됩니다.
+ * (백엔드 엔지니어에게 이 파일의 내용을 공유하세요)
+ */
+
+export type SignalingType =
+  | 'JOIN'
+  | 'LEAVE'
+  | 'CALL_INVITE'
+  | 'CALL_ACCEPT'
+  | 'CALL_REJECT'
+  | 'CALL_END'
+  | 'OFFER'
+  | 'ANSWER'
+  | 'ICE';
+
+/** WebSocket 메시지 공통 래퍼 */
+export interface SignalingMessage {
+  type: SignalingType;
+  roomId: string | null;
+  from: string;
+  to: string;
+  data: SignalingData | null;
+}
+
+// ─────────────────────────────────────────────
+// data 필드 세부 타입 (메시지 종류별 확정 구조)
+// ─────────────────────────────────────────────
+
+/** CALL_INVITE / CALL_ACCEPT 공통 data 구조 */
+export interface CallInviteData {
+  callId: number;
+  cloneUserUuid: string;
+  mediaType: 'VOICE';
+}
+export type CallAcceptData = CallInviteData;
+
+/** OFFER data 구조 */
+export interface OfferData {
+  callId: number;
+  sdp: {
+    type: 'offer';
+    sdp: string;
+  };
+}
+
+/** ANSWER data 구조 */
+export interface AnswerData {
+  callId: number;
+  sdp: {
+    type: 'answer';
+    sdp: string;
+  };
+}
+
+/** ICE data 구조 */
+export interface IceData {
+  callId: number;
+  candidate: {
+    candidate: string;
+    sdpMid: string;
+    sdpMLineIndex: number;
+  };
+}
+
+/** CALL_END data 구조 */
+export interface CallEndData {
+  callId: number;
+}
+
+/** data 필드 유니온 타입 */
+export type SignalingData =
+  | CallInviteData
+  | AnswerData
+  | OfferData
+  | IceData
+  | CallEndData;

--- a/mirror-soul/src/types/signaling.ts
+++ b/mirror-soul/src/types/signaling.ts
@@ -8,6 +8,7 @@
 export type SignalingType =
   | 'JOIN'
   | 'LEAVE'
+  | 'JOINED'
   | 'CALL_INVITE'
   | 'CALL_ACCEPT'
   | 'CALL_REJECT'


### PR DESCRIPTION
## 💡 작업 동기 및 목적
- **AI Twin 통화 시그널링 실패(10초 타임아웃) 버그 해결 및 통신 안정성 확보**
- 기존에는 WebSocket 연결 직후 클라이언트가 `JOIN`과 `CALL_INVITE` 메시지를 연속으로 동시에 발송했습니다. 이로 인해 백엔드 서버에서 사용자 세션을 해당 방에 완전히 바인딩하기도 전에 초대장이 접수되어 메시지가 유실(경쟁 상태, Race Condition)되는 치명적인 오류가 발생했습니다.
- 이를 해결하기 위해 프론트엔드가 백엔드의 응답(`JOINED`)을 확인한 후 안전하게 초대를 발송하도록 **이벤트 동기화(Sequential Event-driven Signaling)** 구조로 리팩토링하였습니다.

## 📝 변경 사항
- [x] **`ws.onopen` 핸들러 분리 및 간소화 (KISS 원칙)**
  - 기존: 소켓 오픈 시 `JOIN` 송신 ➔ 즉시 `CALL_INVITE` 송신 ➔ 10초 타이머 개시
  - 변경: 소켓 오픈 시 **오직 `JOIN` 메시지만 송신**하고 서버의 응답을 대기하도록 책임 축소.
- [x] **`handleMessage` 내 `JOINED` 이벤트 체인 구현 (Event-Driven)**
  - 서버로부터 방 참여가 완료되었다는 `JOINED` 이벤트를 수신한 직후, `CALL_INVITE`를 발송하고 10초 대기 타이머를 시작하도록 로직 이동.
- [x] **클로저 상태 참조 무결성 보장**
  - `handleMessage` 의존성 배열에 `userUuid`를 명시적으로 추가하여 최신 상태값을 안전하게 참조하도록 수정.

## 📸 스크린샷 (선택)
- (UI 변경사항은 없으며, 내부 통신 구조 개선에 해당합니다.)

---

## 🧐 리뷰 포인트 / 기타 특이사항

### 1. 시그널링 흐름 정상화 (Before & After)

> 프론트엔드 내의 경쟁 상태(Race Condition)를 성공적으로 해결한 다이어그램입니다.

```mermaid
sequenceDiagram
    participant App as 프론트엔드
    participant Server as 백엔드 시그널링

    %% [Before] 오류가 나던 동시 전송 방식
    rect rgb(255, 230, 230)
        Note over App, Server: [Before] 오류 상황 (경쟁 상태)
        App->>Server: 1. JOIN (나 들어갈게)
        App->>Server: 2. CALL_INVITE (바로 초대해줘!)
        Note right of Server: 아직 방 세션 등록이<br/>안 끝나서 초대장 유실됨!
        Server-->>App: 3. JOINED (응 등록됐어)
    end

    %% [After] 개선된 순차적 동기화 방식
    rect rgb(230, 255, 230)
        Note over App, Server: [After] 정상 수립 (이벤트 기반 체인)
        App->>Server: 1. JOIN (나 들어갈게)
        Server->>Server: 유저 세션 방 등록 완료
        Server-->>App: 2. JOINED (응 완료됐어!)
        App->>Server: 3. CALL_INVITE (안전하게 초대 발송)
    end
```

### 2. 현재 남은 문제: AI 서버 무응답 병목 지점
> **프론트엔드의 `CALL_INVITE` 송신까지는 완벽하게 성공(로그 검증 완료)**하였으나, 여전히 10초 타임아웃이 발생하고 있습니다. 이는 프론트엔드의 책임 범위를 벗어난, **서버 측 중계 또는 AI 프로세스 쪽 문제**입니다. 어디까지 확인되었는지 다음 다이어그램으로 공유합니다.

```mermaid
graph TD
    A[프론트엔드 App] -->|1. JOIN / CALL_INVITE 정상 발송| B(백엔드 WebSocket 서버)
    
    subgraph Backend_AI ["⚠️ 백엔드 및 AI 서버 검증 필요 영역 ⚠️"]
        B -.->|2. 브로드캐스트 유실 또는 실패?| C{AI 트윈 서버}
        C -.->|3. 서버 죽음/파싱 에러로 무응답?| B
    end
    
    B -.->|4. CALL_ACCEPT 전달되지 않음| A
    
    style A fill:#e6ffe6,stroke:#00cc00,stroke-width:2px
    style B fill:#ffe6e6,stroke:#ff0000,stroke-width:2px,stroke-dasharray: 5 5
    style C fill:#ffe6e6,stroke:#ff0000,stroke-width:2px,stroke-dasharray: 5 5
```
**서버 팀(백엔드/AI) Action Item**:
- 백엔드에서 프론트의 `CALL_INVITE` 패킷을 AI 데몬 소켓으로 정상 릴레이하고 있는지 확인 필요.
- AI 서버 프로세스가 켜져 있고, 정상적으로 방에 JOIN되어 있으며, 초대를 받았을 때 10초 내로 `CALL_ACCEPT`를 돌려주는지 로그 확인 요망.

---

## 🚀 추후 디벨롭 방향 (보안, 성능, 안정성)

본 PR로 시그널링 레이어의 핵심적인 무결성을 확보했습니다. 향후 실제 프로덕션 수준의 고도화를 위해 아래의 디벨롭을 계획하고 있습니다.

#### 1) 네트워크 예외 처리 및 재연결 (안정성)
- **Exponential Backoff 재연결**: 모바일 환경 특성상 지하철 등에서 Wi-Fi ↔ LTE 전환 시 WebSocket이 예기치 않게 끊길 수 있습니다. 연결 유실 시 단순 통화 종료(`_cleanup`)를 넘어 지수 백오프 알고리즘을 이용한 재연결(Reconnection) 로직을 도입해 사용자 경험을 보호합니다.
- **WebRTC ICE Restart**: IP가 변경되어 미디어가 끊겼을 때, 시그널링을 통해 ICE Candidate를 다시 협상하여 끊김 없는 통화를 유지하도록 개선합니다.

#### 2) 에러 추적 및 로깅 고도화 (성능/운영)
- **서버 에러 바디 마스킹 및 Sentry 연동**: Axios 응답 인터셉터에서 403, 500 발생 시 단순 메시지가 아닌 백엔드의 `response.data` 구조(예: `CLONE_NOT_ACTIVE` 등 세부 코드)를 파싱하여 모니터링 도구(Sentry)에 컨텍스트와 함께 적재하도록 에러 핸들러를 보완합니다.

#### 3) JWT 및 인증 갱신 보안 (보안)
- 현 `apiClient`의 토큰 갱신 큐(Failed Queue)가 401 Unauthorized뿐만 아니라, 특정 보안 정책상 **403 Forbidden 상태에서도 만료된 세션임이 판명될 경우** 능동적으로 토큰을 Refresh하거나 사용자 재로그인을 유도할 수 있도록 세션 만료 검사 로직을 더욱 방어적으로(Defensive) 보완할 계획입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI와의 음성 통화 화면 및 통화 흐름(상태 표시/복귀)을 추가
  * 통화 상태 헤더, AI 아바타(연결 시 애니메이션), 통화 제어(UI: 시작/대기/종료) 제공
  * 통화 녹음을 시작하고 종료 시 녹음 파일을 자동 업로드하여 업로드 URL을 처리
  * 앱 내에서 AI 통화 화면으로 이동하는 네비게이션 추가
  * WebRTC 기반 오디오 연결 및 시그널링을 통한 통화 동작 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->