### PR TITLE
fix : 로그아웃 버그 수정 (401에서 403 추가)

### DIFF
--- a/mirror-soul/app/(main)/index.tsx
+++ b/mirror-soul/app/(main)/index.tsx
@@ -10,6 +10,8 @@ import React from 'react';
 import { Alert, ScrollView, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { router } from 'expo-router';
+
 /**
  * 메인 홈 화면 (발견 탭)
  * 로그인 완료 후 진입하는 메인 대시보드입니다.
@@ -27,20 +29,24 @@ export default function MainHomeScreen() {
         {
           text: "로그아웃",
           style: "destructive",
-          onPress: async () => {
-            logger.debug('User clicked logout from Home Settings');
-            try {
-              await logout(); // (1) 서버 세션 종료 시도
-            } catch (error) {
-              logger.warn('Server logout failed, proceeding with local logout', error);
-            } finally {
+          onPress: () => {
+            // iOS Alert가 닫히는 애니메이션 도중에 네비게이션이 실행되면 씹히는 현상 방지를 위해 setTimeout 사용
+            setTimeout(async () => {
+              logger.debug('User clicked logout from Home Settings');
               try {
-                await useAuthStore.getState().logout(); // (2) 항상 로컬 세션 정리
-              } catch (localError) {
-                logger.error('Local logout failed', localError);
-                Alert.alert("알림", "로그아웃 처리 중 문제가 발생했습니다.");
+                await logout(); // (1) 서버 세션 종료 시도
+              } catch (error) {
+                logger.warn('Server logout failed, proceeding with local logout', error);
+              } finally {
+                try {
+                  await useAuthStore.getState().logout(); // (2) 항상 로컬 세션 정리
+                  router.replace('/');
+                } catch (localError) {
+                  logger.error('Local logout failed', localError);
+                  Alert.alert("알림", "로그아웃 처리 중 문제가 발생했습니다.");
+                }
               }
-            }
+            }, 100);
           }
         }
       ]

--- a/mirror-soul/src/services/apiClient.ts
+++ b/mirror-soul/src/services/apiClient.ts
@@ -59,8 +59,8 @@ apiClient.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
 
-    // 401 Unauthorized 에러 시 처리
-    if (error.response?.status === 401) {
+    // 401 Unauthorized 또는 403 Forbidden 에러 시 처리 (백엔드에서 만료된 토큰을 403으로 응답함)
+    if (error.response?.status === 401 || error.response?.status === 403) {
       // [고도화] 인증 경로별 예외 처리 (각각 다른 응답 정책)
       const isLoginPath = originalRequest?.url?.includes('/auth/login');
       const isRefreshPath = originalRequest?.url?.includes('/auth/refresh');
@@ -75,15 +75,15 @@ apiClient.interceptors.response.use(
         });
       }
 
-      // 로그아웃 중 401은 이미 세션이 만료된 것 → 즉시 에러 반환 (상위 finally가 로컬 정리)
+      // 로그아웃 중 401/403은 이미 세션이 만료된 것 → 즉시 에러 반환 (상위 finally가 로컬 정리)
       if (isLogoutPath) {
-        logger.warn('apiClient: Logout returned 401 (session already expired).');
+        logger.warn('apiClient: Logout returned 401/403 (session already expired).');
         return Promise.reject(error);
       }
 
-      // 일반 API 호출 중 401 발생 시에만 토큰 갱신 시도
+      // 일반 API 호출 중 401/403 발생 시에만 토큰 갱신 시도
       if (!originalRequest._retry) {
-        logger.info('apiClient: 401 detected on normal request. Attempting refresh...');
+        logger.info(`apiClient: ${error.response.status} detected on normal request. Attempting refresh...`);
 
         if (isRefreshing) {
           return new Promise((resolve, reject) => {

--- a/mirror-soul/src/store/useAuthStore.ts
+++ b/mirror-soul/src/store/useAuthStore.ts
@@ -2,6 +2,32 @@ import { create } from 'zustand';
 import { tokenStorage } from '../utils/tokenStorage';
 import { logger } from '../utils/logger';
 
+const decodeBase64 = (str: string) => {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+  let output = '';
+  str = String(str).replace(/=+$/, '');
+  for (let bc = 0, bs = 0, buffer, i = 0; (buffer = str.charAt(i++)); ~buffer && (bs = bc % 4 ? bs * 64 + buffer : buffer, bc++ % 4) ? output += String.fromCharCode(255 & bs >> (-2 * bc & 6)) : 0) {
+    buffer = chars.indexOf(buffer);
+  }
+  return output;
+};
+
+const isTokenExpired = (token: string | null) => {
+  if (!token) return true;
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return true;
+    const base64Url = parts[1];
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const jsonPayload = decodeURIComponent(decodeBase64(base64).split('').map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join(''));
+    const payload = JSON.parse(jsonPayload);
+    if (payload.exp) return payload.exp * 1000 < Date.now();
+    return false;
+  } catch (error) {
+    return true;
+  }
+};
+
 interface AuthState {
   isHydrated: boolean; 
   isLoggedIn: boolean;
@@ -26,11 +52,19 @@ export const useAuthStore = create<AuthState>((set, get) => ({
     logger.debug('useAuthStore: Starting hydration...');
     try {
       const accessToken = await tokenStorage.getAccessToken();
+      const refreshToken = await tokenStorage.getRefreshToken();
       const userUuid = await tokenStorage.getUserUuid();
       const userStatus = await tokenStorage.getUserStatus();
       
       if (accessToken && userStatus !== 'ACTIVE') {
         logger.warn(`useAuthStore: Incomplete onboarding detected (${userStatus}). Clearing session.`);
+        await tokenStorage.clearAll();
+        set({ isHydrated: true, isLoggedIn: false, accessToken: null, userUuid: null, userStatus: null });
+        return;
+      }
+      
+      if (accessToken && isTokenExpired(refreshToken)) {
+        logger.warn(`useAuthStore: Refresh token is expired. Clearing session.`);
         await tokenStorage.clearAll();
         set({ isHydrated: true, isLoggedIn: false, accessToken: null, userUuid: null, userStatus: null });
         return;

--- a/mirror-soul/src/store/useAuthStore.ts
+++ b/mirror-soul/src/store/useAuthStore.ts
@@ -2,31 +2,7 @@ import { create } from 'zustand';
 import { tokenStorage } from '../utils/tokenStorage';
 import { logger } from '../utils/logger';
 
-const decodeBase64 = (str: string) => {
-  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
-  let output = '';
-  str = String(str).replace(/=+$/, '');
-  for (let bc = 0, bs = 0, buffer, i = 0; (buffer = str.charAt(i++)); ~buffer && (bs = bc % 4 ? bs * 64 + buffer : buffer, bc++ % 4) ? output += String.fromCharCode(255 & bs >> (-2 * bc & 6)) : 0) {
-    buffer = chars.indexOf(buffer);
-  }
-  return output;
-};
-
-const isTokenExpired = (token: string | null) => {
-  if (!token) return true;
-  try {
-    const parts = token.split('.');
-    if (parts.length !== 3) return true;
-    const base64Url = parts[1];
-    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
-    const jsonPayload = decodeURIComponent(decodeBase64(base64).split('').map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join(''));
-    const payload = JSON.parse(jsonPayload);
-    if (payload.exp) return payload.exp * 1000 < Date.now();
-    return false;
-  } catch (error) {
-    return true;
-  }
-};
+import { isTokenExpired } from '../utils/jwtUtils';
 
 interface AuthState {
   isHydrated: boolean; 

--- a/mirror-soul/src/utils/jwtUtils.ts
+++ b/mirror-soul/src/utils/jwtUtils.ts
@@ -1,0 +1,60 @@
+/**
+ * JWT 및 Base64 관련 유틸리티 함수 모음
+ * SoC (관심사 분리) 원칙에 따라 상태 관리 파일(useAuthStore)에서 토큰 파싱 로직을 분리.
+ */
+
+/**
+ * 브라우저의 atob()나 Node.js의 Buffer 없이 React Native 환경에서 순수 JS로 Base64를 디코딩하는 함수.
+ */
+export const decodeBase64 = (str: string): string => {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=';
+  let output = '';
+  str = String(str).replace(/=+$/, '');
+  
+  for (
+    let bc = 0, bs = 0, buffer, i = 0;
+    (buffer = str.charAt(i++));
+    ~buffer && (bs = bc % 4 ? bs * 64 + buffer : buffer, bc++ % 4)
+      ? (output += String.fromCharCode(255 & (bs >> ((-2 * bc) & 6))))
+      : 0
+  ) {
+    buffer = chars.indexOf(buffer);
+  }
+  return output;
+};
+
+/**
+ * JWT 토큰의 만료 여부를 확인하는 함수.
+ * @param token JWT 토큰 문자열
+ * @returns 만료되었거나 비정상적인 토큰이면 true, 유효하면 false 반환
+ */
+export const isTokenExpired = (token: string | null): boolean => {
+  if (!token) return true;
+  
+  try {
+    const parts = token.split('.');
+    if (parts.length !== 3) return true;
+    
+    const base64Url = parts[1];
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const jsonPayload = decodeURIComponent(
+      decodeBase64(base64)
+        .split('')
+        .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join('')
+    );
+    
+    const payload = JSON.parse(jsonPayload);
+    
+    // [리뷰 반영] exp가 없거나 숫자가 아니면 비정상 토큰으로 간주하여 만료(true) 처리
+    // 보안 보수성(Fail-closed) 원칙 적용
+    if (!payload.exp || typeof payload.exp !== 'number') {
+      return true;
+    }
+    
+    return payload.exp * 1000 < Date.now();
+  } catch (error) {
+    // 파싱 중 에러가 발생해도 안전하게 만료(true) 처리
+    return true;
+  }
+};


### PR DESCRIPTION
## 💡 작업 동기 및 목적
- 이 PR이 왜 필요한가요?
  - **로그아웃 및 토큰 관련 3가지 핵심 버그 수정**:
    1. 앱을 며칠 뒤에 실행했을 때, 로그인을 하지 않았음에도 홈 화면으로 잘못 진입하는 문제.
    2. 진입 후 API 호출 시 `403 Forbidden` 에러가 발생하며 앱이 정상 작동하지 않는 문제.
    3. iOS 기기에서 로그아웃 버튼을 눌렀을 때, 로컬 데이터는 지워지지만 로그인 화면으로 튕겨 나가지 않는 네비게이션 씹힘 문제.
- 연관된 이슈 번호가 있다면 적어주세요.
  - Close #103

## 📝 변경 사항
- 이 PR에서 핵심적으로 변경된 부분을 요약해주세요.
  - [x] `useAuthStore.ts`: `hydrate()` 실행 시 Refresh Token의 JWT `exp`(만료시간) 값을 Base64 디코딩하여 검증하는 로직 추가. 만료된 경우 세션을 초기화하여 홈 화면 진입을 방지함.
  - [x] `apiClient.ts`: 백엔드에서 만료된 토큰에 대해 `401`이 아닌 `403` 에러를 반환하는 점을 대응하기 위해, 인터셉터에 `status === 403` 예외 처리 조건을 추가하여 토큰 리프레시(Refresh) 로직이 정상 작동하도록 수정.
  - [x] `app/(main)/index.tsx`: 로그아웃 확인 `Alert` 창의 확인 버튼(`onPress`) 내부 로직을 `setTimeout(..., 100)`으로 감싸서 iOS의 알림창 닫힘 애니메이션과 `router.replace('/')` 네비게이션 간의 충돌(씹힘) 현상을 해결.

## 📊 로직 흐름 변화 (Before & After)

**🔴 수정 전 (Before)**
```mermaid
sequenceDiagram
    participant User
    participant App
    participant AuthStore
    participant API
    
    %% Issue 1: Hydration without Exp check
    User->>App: 앱 실행 (며칠 후)
    App->>AuthStore: hydrate() 호출
    AuthStore-->>App: 토큰 문자열 존재 확인 (만료여부 X) -> 홈 화면 진입 허용!
    
    %% Issue 2: 403 Error unhandled
    App->>API: API 요청 (만료된 Access Token)
    API-->>App: 403 Forbidden 에러 반환
    App->>App: 401만 갱신하도록 되어있어 403은 그냥 에러 처리 (먹통 발생)
    
    %% Issue 3: iOS Alert Bug
    User->>App: 로그아웃 버튼 클릭 (Alert 창 발생)
    App->>AuthStore: 로그아웃 처리 및 router.replace('/')
    App-->>User: iOS Alert 애니메이션 중 화면 전환 무시됨 (화면 이동 실패)
```

**🟢 수정 후 (After)**
```mermaid
sequenceDiagram
    participant User
    participant App
    participant AuthStore
    participant API
    
    %% Fix 1: Hydration with Exp check
    User->>App: 앱 실행
    App->>AuthStore: hydrate() 호출
    AuthStore->>AuthStore: Refresh Token 만료 여부(exp) 디코딩 및 검증
    alt Refresh Token 만료됨
        AuthStore-->>App: 로컬 세션 초기화 -> 로그인 화면으로 강제 이동
    else Refresh Token 유효함
        AuthStore-->>App: 홈 화면 진입 허용
        %% Fix 2: 403 Error handled
        App->>API: API 요청 (만료된 Access Token)
        API-->>App: 403 Forbidden 반환
        App->>API: 403 감지 -> Refresh Token으로 갱신(Refresh) 요청
        API-->>App: 새 Access Token 발급 및 기존 API 재요청 성공!
    end
    
    %% Fix 3: iOS Alert Bug Fixed
    User->>App: 로그아웃 버튼 클릭 (Alert 창 발생)
    App->>AuthStore: 로그아웃 처리
    App->>App: setTimeout 대기 (100ms) - 애니메이션 종료 대기
    App->>App: router.replace('/') 실행 (충돌 회피)
    App-->>User: 정상적으로 로그인 화면 이동 완료
```

## 🧐 리뷰 포인트 / 기타 특이사항
- **토큰 디코딩 로직 (`useAuthStore.ts`)**: React Native 환경에서는 Node.js의 `Buffer`나 브라우저의 `atob` 함수를 기본적으로 사용할 수 없기 때문에, 외부 라이브러리(`jwt-decode` 등) 설치 없이 순수 JS로 Base64를 디코딩하는 경량화된 함수(`decodeBase64`)를 직접 구현하여 내장했습니다.
- **iOS Alert + Navigation 버그**: iOS 환경 특성상 `Alert.alert` 창이 닫히는 애니메이션 과정 중에 상태 변경이나 라우팅을 시도하면 무시되는 현상이 있습니다. 이를 가장 깔끔하게 해결하기 위해 `setTimeout`으로 비동기 호출 시점을 약간 늦추는 방식을 적용해 두었습니다. 나중에 Custom Modal로 교체된다면 이 `setTimeout`은 제거해도 됩니다.
- **백엔드 HTTP Status 관련**: 현재 백엔드에서는 인증 관련 에러도 `403`으로 응답하고 있습니다. 추후 백엔드에서 만료된 토큰에 대해 `401`을 내려주도록 규칙을 변경한다면, `apiClient.ts`에 추가한 403 인터셉트 예외를 제거해도 무방합니다.

--- 

**상세 구현 내용**
1. `useAuthStore.ts` 최상단에 토큰 디코더 유틸리티 함수 구현 및 `hydrate` 함수 내 `refreshToken`의 잔여 수명 점검 로직 연동 완료.
2. `apiClient.ts` 응답 인터셉터 내 분기문 조건을 `if (error.response?.status === 401 || error.response?.status === 403)` 으로 확장하여 정상 리프레시 사이클 복원.
3. `index.tsx` 내 로그아웃 `onPress` 콜백 전체를 비동기 이벤트 루프 뒤로 미루도록 구조 리팩토링.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 로그아웃 후 앱이 홈 화면으로 안정적으로 돌아가도록 개선했습니다.
  * 인증 오류 상황에서 세션 만료 처리가 더 일관되게 동작하도록 수정했습니다.
  * 리프레시 토큰이 만료된 경우 자동으로 세션을 초기화해 잘못된 로그인 상태가 남지 않도록 했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### 🛠 리팩토링 및 수정 내용

지적해주신 보안 패치와 함께, 요청하신 객체 지향 및 소프트웨어 설계 원칙(SoC, DRY, KISS, SOLID)을 준수하여 코드를 전면 리팩토링했습니다.

1. **`src/utils/jwtUtils.ts` 파일 신규 생성 (SoC, SRP, DRY 원칙 적용)**
   - **SoC (관심사 분리) / SRP (단일 책임 원칙)**: 기존 `useAuthStore.ts`는 Zustand 상태 관리 파일임에도 불구하고, Base64 문자열을 디코딩하고 토큰을 검증하는 이질적인 비즈니스 로직을 가지고 있었습니다. 이를 분리하여 Auth Store는 "상태 관리"만, JWT Utils는 "토큰 파싱 및 검증"만 담당하도록 책임을 나누었습니다.
   - **DRY (중복 배제)**: 이후 다른 컴포넌트나 서비스에서 JWT의 내용(예: 이메일, 권한 등)을 열어봐야 할 때 중복 코드 없이 `jwtUtils.ts`를 재사용할 수 있습니다.

2. **비정상 토큰(exp 누락 등)의 Fail-closed 예외 처리 추가**
   - AI 리뷰를 적극 수용하여, `payload.exp`가 없거나 타입이 `number`가 아닐 경우 즉시 `return true`(만료됨) 처리되도록 방어 로직을 추가했습니다.

3. **가벼운 유틸리티 유지 (KISS 원칙 적용)**
   - 토큰 파싱 하나를 위해 무거운 외부 라이브러리(`jwt-decode`나 `buffer` 폴리필)를 설치하지 않고, 순수 JS 기반의 빠르고 직관적인 Base64 디코더를 작성하여 복잡성을 최소화(KISS)했습니다.

---

### 💻 변경된 코드 구조 (Before & After)

#### 🔴 Before (기존 코드: `useAuthStore.ts`)
```typescript
// Zustand 상태 관리 파일 내부에 파싱 로직이 하드코딩되어 관심사가 혼재됨
const decodeBase64 = (str: string) => { ... }
const isTokenExpired = (token: string | null) => {
    ...
    const payload = JSON.parse(jsonPayload);
    // [보안 취약점] exp가 없으면 무조건 유효(false) 처리됨
    if (payload.exp) return payload.exp * 1000 < Date.now();
    return false; 
}

export const useAuthStore = create<AuthState>(...)
```

#### 🟢 After (리팩토링 된 코드)

**1. `src/utils/jwtUtils.ts` (신규 분리)**
```typescript
/**
 * 브라우저의 atob()나 Node.js의 Buffer 없이 Base64를 디코딩하는 함수.
 */
export const decodeBase64 = (str: string): string => { ... };

export const isTokenExpired = (token: string | null): boolean => {
  if (!token) return true;
  try {
    const parts = token.split('.');
    if (parts.length !== 3) return true;
    
    // ... 디코딩 로직 ...
    const payload = JSON.parse(jsonPayload);
    
    // [리뷰 반영 및 Fail-closed 원칙 적용] 
    // exp가 누락되거나 비정상 값이면 강제로 만료 처리
    if (!payload.exp || typeof payload.exp !== 'number') {
      return true;
    }
    
    return payload.exp * 1000 < Date.now();
  } catch (error) {
    return true;
  }
};
```

**2. `src/store/useAuthStore.ts` (관심사 분리 후 깔끔해짐)**
```typescript
import { create } from 'zustand';
import { tokenStorage } from '../utils/tokenStorage';
import { logger } from '../utils/logger';
import { isTokenExpired } from '../utils/jwtUtils'; // 캡슐화된 모듈만 임포트

interface AuthState { ... }

export const useAuthStore = create<AuthState>((set, get) => ({
    // 깔끔해진 상태 관리 및 hydrate 로직
    ...
}));
```
