### PR TITLE
Refactor/115 history UI

### DIFF
--- a/mirror-soul/app.json
+++ b/mirror-soul/app.json
@@ -29,8 +29,12 @@
       "permissions": [
         "android.permission.RECORD_AUDIO",
         "android.permission.MODIFY_AUDIO_SETTINGS",
+        "android.permission.CAMERA",
+        "android.permission.RECORD_AUDIO",
+        "android.permission.MODIFY_AUDIO_SETTINGS",
         "android.permission.CAMERA"
-      ]
+      ],
+      "package": "com.anonymous.mirrorsoul"
     },
     "web": {
       "output": "static",

--- a/mirror-soul/app/(main)/history.tsx
+++ b/mirror-soul/app/(main)/history.tsx
@@ -2,47 +2,46 @@ import HistoryFilterRow, { HistoryFilterType } from '@/src/components/home/histo
 import HistoryHeader from '@/src/components/home/history/HistoryHeader';
 import HistoryList from '@/src/components/home/history/HistoryList';
 import HistoryStatsRow from '@/src/components/home/history/HistoryStatsRow';
-import {Colors, Layout, Spacing} from '@/src/constants/theme';
+import { Layout, Spacing } from '@/src/constants/theme';
 import { useThemeColors } from '@/src/hooks/useThemeColors';
+import { MOCK_WEEKLY_STATS } from '@/src/mocks/historyMocks';
 import React, { useState } from 'react';
-import { StyleSheet, View, ScrollView } from 'react-native';
+import { ScrollView, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 export default function HistoryScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useThemeColors();
   const [activeFilter, setActiveFilter] = useState<HistoryFilterType>('ALL');
-
-  // 임시 통계 데이터
-  const mockStats = {
-    total: 5,
-    received: 2,
-    sent: 3,
-  };
+  const [searchQuery, setSearchQuery] = useState('');
 
   return (
     <ScrollView
       style={[styles.scrollView, { backgroundColor: colors.background.primary }]}
       contentContainerStyle={[
         styles.scrollContent,
-        { paddingBottom: insets.bottom + Layout.MAIN_TAB_CONTENTS_BOTTOM_PADDING }, // 네비바 높이 + 안전영역 대응
+        { paddingBottom: insets.bottom + Layout.MAIN_TAB_CONTENTS_BOTTOM_PADDING },
       ]}
       showsVerticalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
     >
       <View style={[styles.dashboard, { paddingTop: Math.max(insets.top + 12, Layout.SCREEN_PADDING) }]}>
+        {/* 헤더: 아바타버튼 / History 타이틀 / 설정버튼 */}
         <HistoryHeader />
-        
-        {/* 통계 스코어보드 */}
-        <HistoryStatsRow stats={mockStats} />
-        
-        {/* 필터 탭 */}
+
+        {/* 주간 요약 통계 카드 */}
+        <HistoryStatsRow stats={MOCK_WEEKLY_STATS} />
+
+        {/* 검색 인풋 + 필터 버튼 */}
         <HistoryFilterRow
           activeFilter={activeFilter}
           onFilterChange={setActiveFilter}
+          searchQuery={searchQuery}
+          onSearchChange={setSearchQuery}
         />
-        
-        {/* 리스트 내역 */}
-        <HistoryList filter={activeFilter} />
+
+        {/* 날짜 섹션 그룹 리스트 */}
+        <HistoryList filter={activeFilter} searchQuery={searchQuery} />
       </View>
     </ScrollView>
   );
@@ -60,6 +59,6 @@ const styles = StyleSheet.create({
     width: '100%',
     maxWidth: Layout.MAX_CONTENT_WIDTH,
     alignSelf: 'center',
-    gap: Spacing.md, // 각 행 사이의 간격 조정 (스펙 11.992px에 근사)
+    gap: Spacing.md,
   },
 });

--- a/mirror-soul/app/call-detail.tsx
+++ b/mirror-soul/app/call-detail.tsx
@@ -2,7 +2,7 @@ import CallDetailAlert from '@/src/components/home/history/detail/CallDetailAler
 import CallDetailBody from '@/src/components/home/history/detail/CallDetailBody';
 import CallDetailFooter from '@/src/components/home/history/detail/CallDetailFooter';
 import CallDetailHeader from '@/src/components/home/history/detail/CallDetailHeader';
-import {Colors, FontSize, Spacing} from '@/src/constants/theme';
+import { Colors, FontSize, Spacing } from '@/src/constants/theme';
 import { MOCK_CALL_HISTORY } from '@/src/mocks/historyMocks';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React from 'react';
@@ -12,6 +12,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 /**
  * 통화 기록 상세 화면 (루트 스택 레벨)
  * HistoryCallCard 탭 시 진입하며, BottomNavbar 없이 풀스크린으로 표시됩니다.
+ * 읽기 전용 통화 기록 + Twin 답변 수정 화면입니다. (실시간 채팅 없음)
  */
 export default function CallDetailScreen() {
   const router = useRouter();
@@ -34,9 +35,11 @@ export default function CallDetailScreen() {
       <CallDetailHeader
         name={callItem.name}
         age={callItem.age}
-        callSequenceNumber={callItem.callSequenceNumber}
         consistencyPercent={callItem.consistencyPercent}
+        isOnline={false} // API 연동 시 실제 온라인 상태로 교체
         onBack={() => router.back()}
+        onCallPress={() => {/* 향후 통화 기능 연동 */}}
+        onMorePress={() => {/* 향후 더보기 메뉴 연동 */}}
       />
       <CallDetailAlert />
       <CallDetailBody key={callItem.id} initialMessages={callItem.messages} />
@@ -53,7 +56,7 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.primary.soulBlack,
   },
   errorText: {
-    color: Colors.neutral.lightGray,
+    color: '#99A1AF',
     textAlign: 'center',
     marginTop: Spacing.giant,
     fontFamily: 'Inter',

--- a/mirror-soul/src/components/home/history/HistoryFilterRow.tsx
+++ b/mirror-soul/src/components/home/history/HistoryFilterRow.tsx
@@ -1,40 +1,59 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import HistoryFilterButton from './parts/HistoryFilterButton';
-import { Spacing } from '@/src/constants/theme';
-
+import HistorySearchBar from './parts/HistorySearchBar';
+import { Colors, Radii, Spacing } from '@/src/constants/theme';
+import { useThemeColors } from '@/src/hooks/useThemeColors';
 
 export type HistoryFilterType = 'ALL' | 'RECEIVED' | 'SENT';
+
+/** 필터 버튼 데이터 정의 (DRY — 레이블·타입 한 곳에서 관리) */
+const FILTER_OPTIONS: { type: HistoryFilterType; label: string }[] = [
+  { type: 'ALL', label: '전체' },
+  { type: 'RECEIVED', label: '받음' },
+  { type: 'SENT', label: '보냄' },
+];
 
 interface HistoryFilterRowProps {
   activeFilter: HistoryFilterType;
   onFilterChange: (filter: HistoryFilterType) => void;
+  searchQuery: string;
+  onSearchChange: (text: string) => void;
 }
 
 /**
- * 전체 / 받은 통화 / 보낸 통화 필터 버튼 그룹
+ * 검색 인풋 + 필터 버튼 그룹 Row (SRP)
+ * SearchBar와 FilterButton들을 가로로 배치합니다.
  */
 export default function HistoryFilterRow({
   activeFilter,
   onFilterChange,
+  searchQuery,
+  onSearchChange,
 }: HistoryFilterRowProps) {
+  const { colors } = useThemeColors();
+
   return (
     <View style={styles.container}>
-      <HistoryFilterButton
-        label="전체"
-        isActive={activeFilter === 'ALL'}
-        onPress={() => onFilterChange('ALL')}
-      />
-      <HistoryFilterButton
-        label="받은 통화"
-        isActive={activeFilter === 'RECEIVED'}
-        onPress={() => onFilterChange('RECEIVED')}
-      />
-      <HistoryFilterButton
-        label="보낸 통화"
-        isActive={activeFilter === 'SENT'}
-        onPress={() => onFilterChange('SENT')}
-      />
+      {/* 검색 인풋 (flex:1로 가용 공간 확장) */}
+      <HistorySearchBar value={searchQuery} onChangeText={onSearchChange} />
+
+      {/* 필터 버튼 컨테이너 */}
+      <View
+        style={[
+          styles.filterGroup,
+          { backgroundColor: colors.background.glass, borderColor: colors.border.primary },
+        ]}
+      >
+        {FILTER_OPTIONS.map(({ type, label }) => (
+          <HistoryFilterButton
+            key={type}
+            label={label}
+            isActive={activeFilter === type}
+            onPress={() => onFilterChange(type)}
+          />
+        ))}
+      </View>
     </View>
   );
 }
@@ -44,6 +63,15 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignSelf: 'stretch',
     alignItems: 'center',
-    gap: Spacing.sm, // 7.995px 반올림
+    gap: Spacing.sm,
+  },
+  filterGroup: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: Spacing.xs,
+    borderRadius: Radii.lg,
+    borderWidth: 0.612,
+    gap: Spacing.xxs,
+    height: 48,
   },
 });

--- a/mirror-soul/src/components/home/history/HistoryHeader.tsx
+++ b/mirror-soul/src/components/home/history/HistoryHeader.tsx
@@ -1,34 +1,71 @@
-import {Colors, FontFamily, FontSize, FontWeight, Spacing} from '@/src/constants/theme';
-import { useThemeColors } from '@/src/hooks/useThemeColors';
 import React from 'react';
-import { StyleSheet, View, Text } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import { Colors, FontFamily, FontSize, FontWeight, Radii, Spacing } from '@/src/constants/theme';
+import { useThemeColors } from '@/src/hooks/useThemeColors';
 
 /**
  * HistoryHeader 컴포넌트 (SRP)
- * 기록 화면의 상단 타이틀 영역을 렌더링합니다.
+ * 기록 화면 상단 3-slot 헤더를 렌더링합니다.
+ *
+ * [아바타 버튼] [History 타이틀] [설정 버튼]
  */
 export default function HistoryHeader() {
   const { colors } = useThemeColors();
+  const router = useRouter();
+
   return (
     <View style={styles.container}>
-      <Text style={[styles.title, { color: colors.text.primary }]}>통화 기록</Text>
+      {/* 좌측: 아바타/프로필 버튼 */}
+      <TouchableOpacity
+        style={[styles.iconButton, { backgroundColor: colors.background.glass, borderColor: colors.border.primary }]}
+        onPress={() => router.push('/profile')}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel="내 프로필"
+      >
+        <Feather name="user" size={20} color={colors.text.secondary} />
+      </TouchableOpacity>
+
+      {/* 중앙: 타이틀 */}
+      <Text style={[styles.title, { color: colors.text.primary }]}>History</Text>
+
+      {/* 우측: 설정 버튼 */}
+      <TouchableOpacity
+        style={[styles.iconButton, { backgroundColor: colors.background.glass, borderColor: colors.border.primary }]}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel="설정"
+      >
+        <Feather name="settings" size={20} color={colors.text.secondary} />
+      </TouchableOpacity>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    height: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    height: 52,
     alignSelf: 'stretch',
+    paddingTop: Spacing.sm,
+  },
+  iconButton: {
+    width: 44,
+    height: 44,
+    borderRadius: Radii.lg,
+    borderWidth: 0.612,
     justifyContent: 'center',
     alignItems: 'center',
-    paddingTop: Spacing.sm,
   },
   title: {
     fontFamily: FontFamily.sans,
-    fontSize: FontSize.xxl,
-    fontWeight: FontWeight.medium,
-    lineHeight: 28, // 140%
-    letterSpacing: -0.449,
+    fontSize: FontSize.xxxl,
+    fontWeight: FontWeight.black as any,
+    letterSpacing: -1.13,
+    lineHeight: 32,
   },
 });

--- a/mirror-soul/src/components/home/history/HistoryList.tsx
+++ b/mirror-soul/src/components/home/history/HistoryList.tsx
@@ -1,52 +1,110 @@
 import { MOCK_CALL_HISTORY } from '@/src/mocks/historyMocks';
 import { useRouter } from 'expo-router';
-import React from 'react';
-import { FlatList, StyleSheet, View } from 'react-native';
+import React, { useMemo } from 'react';
+import { SectionList, StyleSheet, Text, View } from 'react-native';
 import { HistoryFilterType } from './HistoryFilterRow';
 import HistoryCallCard from './parts/HistoryCallCard';
+import HistoryDateSectionHeader from './parts/HistoryDateSectionHeader';
 import { Spacing } from '@/src/constants/theme';
-
+import { useThemeColors } from '@/src/hooks/useThemeColors';
+import { HistoryCallItemData } from './parts/HistoryCallCard';
 
 interface HistoryListProps {
   filter: HistoryFilterType;
+  searchQuery: string;
 }
 
-export default function HistoryList({ filter }: HistoryListProps) {
-  const router = useRouter();
+interface HistorySection {
+  title: string;
+  data: HistoryCallItemData[];
+}
 
-  // 필터링 로직: 표시 문자열이 아닌 도메인 데이터(direction)를 기준으로 판정
-  const data = MOCK_CALL_HISTORY.filter((item) => {
-    if (filter === 'ALL') return true;
-    return item.direction === filter;
-  });
+/**
+ * 필터·검색 결과를 날짜 섹션별로 그룹핑하여 표시합니다. (SRP)
+ *
+ * - filter: 방향 필터 (ALL / RECEIVED / SENT)
+ * - searchQuery: 이름 또는 태그 기반 텍스트 검색
+ * - 결과를 dateStr 기준으로 SectionList 섹션으로 변환합니다.
+ */
+export default function HistoryList({ filter, searchQuery }: HistoryListProps) {
+  const router = useRouter();
+  const { colors } = useThemeColors();
+
+  const sections: HistorySection[] = useMemo(() => {
+    const query = searchQuery.toLowerCase().trim();
+
+    // 1) 방향 필터
+    const directionFiltered = MOCK_CALL_HISTORY.filter((item) => {
+      if (filter === 'ALL') return true;
+      return item.direction === filter;
+    });
+
+    // 2) 텍스트 검색 필터 (이름 또는 태그)
+    const searched = query
+      ? directionFiltered.filter(
+          (item) =>
+            item.name.toLowerCase().includes(query) ||
+            item.tags.some((tag) => tag.toLowerCase().includes(query)),
+        )
+      : directionFiltered;
+
+    // 3) dateStr 기준으로 그룹핑 (순서 유지)
+    const groupMap: Map<string, HistoryCallItemData[]> = new Map();
+    for (const item of searched) {
+      const key = item.dateStr;
+      if (!groupMap.has(key)) groupMap.set(key, []);
+      groupMap.get(key)!.push(item);
+    }
+
+    return Array.from(groupMap.entries()).map(([title, data]) => ({ title, data }));
+  }, [filter, searchQuery]);
+
+  if (sections.length === 0) {
+    return (
+      <View style={styles.emptyContainer}>
+        <Text style={[styles.emptyText, { color: colors.text.muted }]}>기록이 없습니다</Text>
+      </View>
+    );
+  }
 
   return (
-    <View style={styles.container}>
-      <FlatList
-        data={data}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <HistoryCallCard
-            data={item}
-            onPress={() =>
-              router.push({ pathname: '/call-detail', params: { id: item.id } })
-            }
-          />
-        )}
-        contentContainerStyle={styles.listContent}
-        showsVerticalScrollIndicator={false}
-        scrollEnabled={false} // 부모 ScrollView에 의해 스크롤됨
-      />
-    </View>
+    <SectionList<HistoryCallItemData, HistorySection>
+      sections={sections}
+      keyExtractor={(item) => item.id}
+      renderSectionHeader={({ section }) => (
+        <HistoryDateSectionHeader dateLabel={section.title} />
+      )}
+      renderItem={({ item, index }) => (
+        <HistoryCallCard
+          data={item}
+          index={index}
+          onPress={() => router.push({ pathname: '/call-detail', params: { id: item.id } })}
+        />
+      )}
+      ItemSeparatorComponent={() => <View style={styles.separator} />}
+      SectionSeparatorComponent={() => <View style={styles.sectionSeparator} />}
+      showsVerticalScrollIndicator={false}
+      scrollEnabled={false} // 부모 ScrollView가 스크롤을 담당
+      stickySectionHeadersEnabled={false}
+    />
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    alignSelf: 'stretch',
-    flex: 1,
+  emptyContainer: {
+    paddingVertical: 80,
+    alignItems: 'center',
   },
-  listContent: {
-    gap: Spacing.md,
+  emptyText: {
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+  },
+  separator: {
+    height: Spacing.sm,
+  },
+  sectionSeparator: {
+    height: Spacing.sm,
   },
 });

--- a/mirror-soul/src/components/home/history/HistoryStatsRow.tsx
+++ b/mirror-soul/src/components/home/history/HistoryStatsRow.tsx
@@ -1,47 +1,187 @@
-import {Colors, Spacing} from '@/src/constants/theme';
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
-import HistoryStatCard from './parts/HistoryStatCard';
+import { StyleSheet, Text, View } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { LinearGradient } from 'expo-linear-gradient';
+import { Colors, FontFamily, FontSize, FontWeight, Radii, Spacing } from '@/src/constants/theme';
+import { useThemeColors } from '@/src/hooks/useThemeColors';
 
-interface HistoryStatsData {
-  total: number;
+interface WeeklyStats {
+  totalHours: number;
   received: number;
   sent: number;
+  weeklyGrowthPercent: number;
 }
 
 interface HistoryStatsRowProps {
-  stats: HistoryStatsData;
+  stats: WeeklyStats;
 }
 
 /**
- * 3개의 통계 카드를 가로로 배치하는 Row 컴포넌트
+ * HistoryStatsRow 컴포넌트 (SRP)
+ * 주간 통화 요약을 단일 통합 카드로 표시합니다.
+ *
+ * 레이아웃:
+ *   [Weekly Summary 레이블]  [+N% 증가율 배지]
+ *   [누적 대화 시간]  |  [받음 카운트(cyan) / 보냄 카운트(purple)]
  */
 export default function HistoryStatsRow({ stats }: HistoryStatsRowProps) {
+  const { colors } = useThemeColors();
+
   return (
-    <View style={styles.container}>
-      <HistoryStatCard
-        count={stats.total}
-        label="전체 통화"
-      />
-      <HistoryStatCard
-        count={stats.received}
-        label="받은 통화"
-        countColor={Colors.primary.electricCyan} // 00D3F3
-      />
-      <HistoryStatCard
-        count={stats.sent}
-        label="보낸 통화"
-        countColor={Colors.primary.vividPurple} // C27AFF
-      />
+    <View style={[styles.card, { backgroundColor: colors.background.glass, borderColor: colors.border.primary }]}>
+      {/* 상단: 레이블 + 증가율 */}
+      <View style={styles.topRow}>
+        <Text style={[styles.sectionLabel, { color: Colors.primary.electricCyan }]}>
+          WEEKLY SUMMARY
+        </Text>
+        <View style={styles.growthBadge}>
+          <Feather name="trending-up" size={10} color={Colors.primary.successGreen} />
+          <Text style={styles.growthText}>+{stats.weeklyGrowthPercent}%</Text>
+        </View>
+      </View>
+
+      {/* 하단: 시간 + 구분선 + 카운트 */}
+      <View style={styles.bottomRow}>
+        {/* 누적 대화 시간 */}
+        <View style={styles.hoursBlock}>
+          <View style={styles.hoursValueRow}>
+            <Text style={[styles.hoursNumber, { color: colors.text.primary }]}>
+              {stats.totalHours}
+            </Text>
+            <Text style={[styles.hoursUnit, { color: colors.text.muted }]}>시간</Text>
+          </View>
+          <Text style={[styles.hoursLabel, { color: colors.text.muted }]}>누적 대화 시간</Text>
+        </View>
+
+        {/* 수직 구분선 */}
+        <View style={[styles.verticalDivider, { backgroundColor: colors.border.primary }]} />
+
+        {/* 받음/보냄 카운트 */}
+        <View style={styles.countsBlock}>
+          {/* 받음 */}
+          <View style={styles.countItem}>
+            <View style={styles.countValueRow}>
+              <Feather name="arrow-down-left" size={12} color={Colors.primary.electricCyan} />
+              <Text style={[styles.countNumber, { color: Colors.primary.electricCyan }]}>
+                {String(stats.received).padStart(2, '0')}
+              </Text>
+            </View>
+            <Text style={[styles.countLabel, { color: colors.text.muted }]}>받음</Text>
+          </View>
+
+          {/* 보냄 */}
+          <View style={styles.countItem}>
+            <View style={styles.countValueRow}>
+              <Feather name="arrow-up-right" size={12} color={Colors.primary.vividPurple} />
+              <Text style={[styles.countNumber, { color: Colors.primary.vividPurple }]}>
+                {String(stats.sent).padStart(2, '0')}
+              </Text>
+            </View>
+            <Text style={[styles.countLabel, { color: colors.text.muted }]}>보냄</Text>
+          </View>
+        </View>
+      </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
+  card: {
     alignSelf: 'stretch',
+    paddingVertical: Spacing.xl,
+    paddingHorizontal: Spacing.xl,
+    borderRadius: Radii.xxl,
+    borderWidth: 0.612,
+    gap: Spacing.md,
+  },
+  topRow: {
+    flexDirection: 'row',
     alignItems: 'center',
-    gap: Spacing.sm, // 카드 사이 간격. 스펙에는 구체적으로 없으나 344px 맞춰 균등 배치
+    justifyContent: 'space-between',
+  },
+  sectionLabel: {
+    fontFamily: FontFamily.sans,
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.black as any,
+    letterSpacing: 2.1,
+    textTransform: 'uppercase',
+  },
+  growthBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xxs,
+  },
+  growthText: {
+    fontFamily: FontFamily.sans,
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.bold,
+    color: Colors.primary.successGreen,
+  },
+  bottomRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: Spacing.xl,
+  },
+  hoursBlock: {
+    flex: 1,
+    flexDirection: 'column',
+    gap: Spacing.xxs,
+  },
+  hoursValueRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: Spacing.xs,
+  },
+  hoursNumber: {
+    fontFamily: FontFamily.sans,
+    fontSize: 30,
+    fontWeight: FontWeight.black as any,
+    letterSpacing: -1,
+    lineHeight: 34,
+  },
+  hoursUnit: {
+    fontFamily: FontFamily.sans,
+    fontSize: FontSize.sm,
+    fontWeight: FontWeight.regular,
+    marginBottom: 2,
+  },
+  hoursLabel: {
+    fontFamily: FontFamily.sans,
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.bold,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+  },
+  verticalDivider: {
+    width: StyleSheet.hairlineWidth,
+    alignSelf: 'stretch',
+  },
+  countsBlock: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xl,
+    paddingLeft: Spacing.sm,
+  },
+  countItem: {
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    gap: Spacing.xxs,
+  },
+  countValueRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xxs,
+  },
+  countNumber: {
+    fontFamily: FontFamily.mono,
+    fontSize: FontSize.base,
+    fontWeight: FontWeight.black as any,
+  },
+  countLabel: {
+    fontFamily: FontFamily.sans,
+    fontSize: 8,
+    fontWeight: FontWeight.black as any,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
   },
 });

--- a/mirror-soul/src/components/home/history/detail/CallDetailAlert.tsx
+++ b/mirror-soul/src/components/home/history/detail/CallDetailAlert.tsx
@@ -1,23 +1,20 @@
-import EditPencilIcon from '@/assets/images/common/history/call_history/call_edit_pencil.svg';
-import PurpleInfoIcon from '@/assets/images/common/history/call_history/puple_info.svg';
-import {Colors, FontFamily, FontSize, FontWeight, Spacing} from '@/src/constants/theme';
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors, FontFamily, FontSize, FontWeight, Spacing } from '@/src/constants/theme';
 
 /**
- * 통화 상세 상단 알림 배너 (SRP)
- * 편집 기능 안내 문구를 자주색 글래스 배너로 표시합니다.
+ * 통화 상세 유사도 힌트 배너 (SRP)
+ * 유사도가 높아 대화가 잘 통할 것임을 Sparkles + cyan 글래스 배너로 안내합니다.
  */
 export default function CallDetailAlert() {
   return (
     <View style={styles.container}>
       <View style={styles.row}>
-        <PurpleInfoIcon width={16} height={16} />
-        <View style={styles.paragraph}>
-          <Text style={styles.text}>우측 상단의 </Text>
-          <EditPencilIcon width={12} height={12} />
-          <Text style={styles.text}> 아이콘을 탭하여 내 Twin의 답변을 수정할 수 있습니다</Text>
-        </View>
+        <Feather name="zap" size={14} color={Colors.primary.electricCyan} />
+        <Text style={styles.text}>
+          유사도가 높아 대화가 잘 통할 확률이 높아요
+        </Text>
       </View>
     </View>
   );
@@ -25,30 +22,23 @@ export default function CallDetailAlert() {
 
 const styles = StyleSheet.create({
   container: {
-    paddingHorizontal: Spacing.md,
-    paddingTop: Spacing.md,
-    paddingBottom: Spacing.md,
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.md,
     borderBottomWidth: 0.612,
-    borderBottomColor: Colors.glass.purple20,
-    backgroundColor: Colors.glass.purple10,
+    borderBottomColor: Colors.glass.cyan20_d3,
+    backgroundColor: Colors.glass.cyan10_d3,
   },
   row: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: Spacing.sm,
-    alignSelf: 'stretch',
-  },
-  paragraph: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    flexWrap: 'wrap',
+    justifyContent: 'center',
   },
   text: {
-    color: Colors.neutral.lavender,
+    color: Colors.primary.electricCyan,
     fontFamily: FontFamily.sans,
     fontSize: FontSize.sm,
-    fontWeight: FontWeight.regular,
+    fontWeight: FontWeight.medium,
     lineHeight: 16,
   },
 });

--- a/mirror-soul/src/components/home/history/detail/CallDetailFooter.tsx
+++ b/mirror-soul/src/components/home/history/detail/CallDetailFooter.tsx
@@ -1,15 +1,17 @@
-import {Colors, FontFamily, FontSize, FontWeight, Spacing} from '@/src/constants/theme';
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors, FontFamily, FontSize, FontWeight, Radii, Spacing } from '@/src/constants/theme';
 
 /**
  * 통화 상세 하단 푸터 (SRP)
- * Twin 학습 안내 문구를 표시합니다.
+ * Twin 학습 반영 안내 문구를 pill 배지 형태로 표시합니다.
  */
 export default function CallDetailFooter() {
   return (
     <View style={styles.container}>
-      <View style={styles.row}>
+      <View style={styles.badge}>
+        <Feather name="zap" size={12} color={Colors.primary.electricCyan} />
         <Text style={styles.text}>수정된 답변은 Twin의 학습에 반영됩니다</Text>
       </View>
     </View>
@@ -24,20 +26,24 @@ const styles = StyleSheet.create({
     borderTopWidth: 0.612,
     borderTopColor: Colors.glass.white10,
     backgroundColor: Colors.glass.black40,
-  },
-  row: {
-    flexDirection: 'row',
-    justifyContent: 'center',
     alignItems: 'center',
-    gap: Spacing.sm,
-    alignSelf: 'stretch',
+  },
+  badge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm,
+    borderRadius: Radii.full,
+    backgroundColor: Colors.glass.cyan10_d3,
+    borderWidth: 0.612,
+    borderColor: Colors.glass.cyan20_d3,
   },
   text: {
-    color: Colors.neutral.lightGray,
+    color: Colors.primary.electricCyan,
     fontFamily: FontFamily.sans,
     fontSize: FontSize.sm,
-    fontWeight: FontWeight.regular,
+    fontWeight: FontWeight.medium,
     lineHeight: 16,
-    textAlign: 'center',
   },
 });

--- a/mirror-soul/src/components/home/history/detail/CallDetailHeader.tsx
+++ b/mirror-soul/src/components/home/history/detail/CallDetailHeader.tsx
@@ -1,68 +1,89 @@
-import RightNarrowIcon from '@/assets/images/common/Right_narrow.svg';
-import {Colors, Radii, FontFamily, FontSize, FontWeight, Spacing} from '@/src/constants/theme';
-import { LinearGradient } from 'expo-linear-gradient';
 import React from 'react';
-import {
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors, FontFamily, FontSize, FontWeight, Radii, Spacing } from '@/src/constants/theme';
 
 interface CallDetailHeaderProps {
   name: string;
   age: number;
-  callSequenceNumber: number;
   consistencyPercent: number;
+  isOnline?: boolean;
   onBack: () => void;
+  onCallPress?: () => void;
+  onMorePress?: () => void;
 }
 
 /**
  * 통화 상세 헤더 (SRP)
- * 뒤로가기 버튼, 이름/나이/부제목, 일치도 배지를 렌더링합니다.
+ * 채팅 헤더 스타일로 재설계:
+ *   [뒤로가기] [아바타 + 이름/유사도/온라인 상태] [전화 버튼] [더보기 버튼]
  */
 export default function CallDetailHeader({
   name,
   age,
-  callSequenceNumber,
   consistencyPercent,
+  isOnline = false,
   onBack,
+  onCallPress,
+  onMorePress,
 }: CallDetailHeaderProps) {
   return (
     <View style={styles.container}>
-      <View style={styles.row}>
-        {/* 뒤로가기 */}
-        <TouchableOpacity
-          onPress={onBack}
-          style={styles.backButton}
-          activeOpacity={0.7}
-          accessibilityRole="button"
-          accessibilityLabel="뒤로가기"
-        >
-          <RightNarrowIcon
-            width={20}
-            height={20}
-            style={{ transform: [{ rotate: '180deg' }] }}
-          />
-        </TouchableOpacity>
+      {/* 뒤로가기 */}
+      <TouchableOpacity
+        onPress={onBack}
+        style={styles.iconButton}
+        activeOpacity={0.7}
+        accessibilityRole="button"
+        accessibilityLabel="뒤로가기"
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+      >
+        <Feather name="arrow-left" size={20} color={Colors.neutral.pureWhite} />
+      </TouchableOpacity>
 
-        {/* 이름 + 부제목 */}
-        <View style={styles.content}>
-          <Text style={styles.title}>{name}, {age}</Text>
-          <Text style={styles.subtitle}>
-            {name}님과의 {callSequenceNumber}번 째 대화 내용
-          </Text>
+      {/* 아바타 + 이름/유사도 */}
+      <View style={styles.profileSection}>
+        {/* 아바타 */}
+        <View style={styles.avatarWrapper}>
+          <View style={styles.avatar}>
+            <Text style={styles.avatarInitial}>{name[0]}</Text>
+          </View>
+          {isOnline && <View style={styles.onlineDot} />}
         </View>
 
-        {/* 일치도 배지 */}
-        <LinearGradient
-          colors={[Colors.glass.cyan20, Colors.glass.purple20]}
-          start={{ x: 0, y: 0.5 }}
-          end={{ x: 1, y: 0.5 }}
-          style={styles.badge}
+        {/* 텍스트 정보 */}
+        <View style={styles.textInfo}>
+          <Text style={styles.nameText}>{name}</Text>
+          <View style={styles.subRow}>
+            <Text style={styles.consistencyText}>유사도 {consistencyPercent}%</Text>
+            <View style={styles.dot} />
+            {isOnline && (
+              <Text style={styles.onlineText}>상대방이 읽음</Text>
+            )}
+          </View>
+        </View>
+      </View>
+
+      {/* 우측 액션 버튼 */}
+      <View style={styles.actions}>
+        <TouchableOpacity
+          style={styles.iconButton}
+          onPress={onCallPress}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel="통화"
         >
-          <Text style={styles.badgeText}>{consistencyPercent}%</Text>
-        </LinearGradient>
+          <Feather name="phone" size={16} color={Colors.neutral.pureWhite} />
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.iconButton}
+          onPress={onMorePress}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel="더보기"
+        >
+          <Feather name="more-vertical" size={16} color={Colors.neutral.pureWhite} />
+        </TouchableOpacity>
       </View>
     </View>
   );
@@ -70,59 +91,101 @@ export default function CallDetailHeader({
 
 const styles = StyleSheet.create({
   container: {
+    flexDirection: 'row',
+    alignItems: 'center',
     paddingHorizontal: Spacing.lg,
-    paddingTop: Spacing.lg,
-    paddingBottom: Spacing.lg,
+    paddingVertical: Spacing.md,
+    gap: Spacing.md,
     borderBottomWidth: 0.612,
     borderBottomColor: Colors.glass.white10,
     backgroundColor: Colors.glass.black40,
   },
-  row: {
+  profileSection: {
+    flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
     gap: Spacing.md,
-    alignSelf: 'stretch',
-    height: 52,
   },
-  backButton: {
-    width: 32,
-    height: 32,
-    justifyContent: 'center',
-    alignItems: 'center',
+  avatarWrapper: {
+    position: 'relative',
+    width: 40,
+    height: 40,
   },
-  content: {
-    flex: 1,
-    flexDirection: 'column',
-  },
-  title: {
-    color: Colors.neutral.pureWhite,
-    fontFamily: FontFamily.sans,
-    fontSize: FontSize.xxxl,
-    fontWeight: FontWeight.medium,
-    lineHeight: 36,
-    letterSpacing: 0.07,
-  },
-  subtitle: {
-    color: Colors.neutral.lightGray,
-    fontFamily: FontFamily.sans,
-    fontSize: FontSize.sm,
-    fontWeight: FontWeight.regular,
-    lineHeight: 16,
-  },
-  badge: {
-    paddingHorizontal: 14,
-    paddingVertical: Spacing.sm,
-    borderRadius: Radii.full,
+  avatar: {
+    width: 40,
+    height: 40,
+    borderRadius: Radii.lg,
+    backgroundColor: Colors.glass.cyan20_d3,
     borderWidth: 0.612,
-    borderColor: Colors.glass.cyan30_d3,
+    borderColor: Colors.glass.white10,
     justifyContent: 'center',
     alignItems: 'center',
   },
-  badgeText: {
+  avatarInitial: {
     color: Colors.primary.electricCyan,
     fontFamily: FontFamily.sans,
-    fontSize: FontSize.sm,
-    fontWeight: FontWeight.regular,
-    lineHeight: 16,
+    fontSize: FontSize.lg,
+    fontWeight: FontWeight.bold,
+  },
+  onlineDot: {
+    position: 'absolute',
+    bottom: -1,
+    right: -1,
+    width: 10,
+    height: 10,
+    borderRadius: Radii.full,
+    backgroundColor: Colors.primary.successGreen,
+    borderWidth: 1.5,
+    borderColor: Colors.primary.soulBlack,
+  },
+  textInfo: {
+    flex: 1,
+    flexDirection: 'column',
+    gap: 2,
+  },
+  nameText: {
+    color: Colors.neutral.pureWhite,
+    fontFamily: FontFamily.sans,
+    fontSize: FontSize.base,
+    fontWeight: FontWeight.semibold,
+    letterSpacing: -0.15,
+  },
+  subRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xs,
+  },
+  consistencyText: {
+    color: Colors.neutral.darkGray,
+    fontFamily: FontFamily.sans,
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.medium,
+  },
+  dot: {
+    width: 3,
+    height: 3,
+    borderRadius: Radii.full,
+    backgroundColor: Colors.neutral.darkGray,
+  },
+  onlineText: {
+    color: Colors.primary.successGreen,
+    fontFamily: FontFamily.sans,
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.medium,
+  },
+  actions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
+  iconButton: {
+    width: 36,
+    height: 36,
+    borderRadius: Radii.full,
+    backgroundColor: Colors.glass.white10,
+    borderWidth: 0.612,
+    borderColor: Colors.glass.white10,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 });

--- a/mirror-soul/src/components/home/history/parts/HistoryCallCard.tsx
+++ b/mirror-soul/src/components/home/history/parts/HistoryCallCard.tsx
@@ -1,11 +1,12 @@
-import {Colors, Radii, Spacing} from '@/src/constants/theme';
+import { Colors, Radii, Spacing } from '@/src/constants/theme';
 import { useThemeColors } from '@/src/hooks/useThemeColors';
 import React from 'react';
 import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import Animated, { FadeInDown } from 'react-native-reanimated';
 
-import CallProfile from './HistoryCallCard/CallProfile';
-import CallSubInfo from './HistoryCallCard/CallSubInfo';
-import CallTagRow from './HistoryCallCard/CallTagRow';
+import CallAvatar from './HistoryCallCard/CallProfile';
+import CallMeta from './HistoryCallCard/CallSubInfo';
 
 /**
  * 통화 내 단일 메시지 데이터 모델 (SRP)
@@ -32,55 +33,94 @@ export interface HistoryCallItemData {
   durationLabel: string;
   twinMatchLabel: string;
   tags: string[];
+  isNew?: boolean;                 // 새로운 통화 기록 여부 (읽지 않음)
+  satisfactionPercent?: number;    // 만족도 퍼센트
   messages: ChatMessage[];         // 통화 내 메시지 목록
 }
 
 interface HistoryCallCardProps {
   data: HistoryCallItemData;
+  index?: number;               // stagger 애니메이션용
   onPress?: () => void;
 }
 
 /**
  * 개별 통화 기록 단위 카드 컴포넌트
+ *
+ * 레이아웃:
+ *   [CallAvatar] [CallMeta(이름/일치도/시간/태그)] [ChevronRight]
+ *
+ * isNew=true 시:
+ *   - electricCyan 테두리
+ *   - 우상단 cyan glowing dot indicator
  */
-export default function HistoryCallCard({ data, onPress }: HistoryCallCardProps) {
+export default function HistoryCallCard({ data, index = 0, onPress }: HistoryCallCardProps) {
   const { colors } = useThemeColors();
 
+  const borderColor = data.isNew
+    ? Colors.primary.electricCyan
+    : colors.border.primary;
+
+  const backgroundColor = data.isNew
+    ? Colors.glass.cyan10_d3
+    : colors.background.glass;
+
   return (
-    <TouchableOpacity
-      style={[styles.container, { backgroundColor: colors.background.glass, borderColor: colors.border.primary }]}
-      onPress={onPress}
-      activeOpacity={0.85}
-      accessibilityRole="button"
-    >
-      <CallProfile
-        name={data.name}
-        age={data.age}
-        consistencyPercent={data.consistencyPercent}
-        dateStr={data.dateStr}
-        timeStr={data.timeStr}
-        profileImageUrl={data.profileImageUrl}
-        callTypeDesc={data.callTypeDesc}
-      />
-      <CallSubInfo
-        durationLabel={data.durationLabel}
-        twinMatchLabel={data.twinMatchLabel}
-      />
-      <CallTagRow tags={data.tags} />
-    </TouchableOpacity>
+    <Animated.View entering={FadeInDown.delay(index * 60).duration(350).springify()}>
+      <TouchableOpacity
+        style={[styles.container, { backgroundColor, borderColor }]}
+        onPress={onPress}
+        activeOpacity={0.82}
+        accessibilityRole="button"
+      >
+        {/* 아바타 + 방향 배지 */}
+        <CallAvatar
+          name={data.name}
+          profileImageUrl={data.profileImageUrl}
+          direction={data.direction}
+        />
+
+        {/* 이름 / 일치도 / 시간 / 태그 */}
+        <CallMeta
+          name={data.name}
+          age={data.age}
+          consistencyPercent={data.consistencyPercent}
+          timeStr={data.timeStr}
+          durationLabel={data.durationLabel}
+          tags={data.tags}
+        />
+
+        {/* ChevronRight */}
+        <Feather name="chevron-right" size={16} color={colors.text.muted} style={styles.chevron} />
+
+        {/* NEW dot indicator (isNew=true 시에만) */}
+        {data.isNew && <View style={styles.newDot} />}
+      </TouchableOpacity>
+    </Animated.View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    paddingTop: 16.6,
-    paddingHorizontal: 16.6,
-    paddingBottom: 16.6, // 상단 여백과 동일하게 맞춤(16.6)
-    flexDirection: 'column',
-    alignItems: 'flex-start',
-    gap: Spacing.md, // 11.992px 반올림
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
     alignSelf: 'stretch',
-    borderRadius: Radii.lg, // 16px
+    borderRadius: Radii.xxl,   // 32px — 레퍼런스의 rounded-3xl
     borderWidth: 0.612,
+  },
+  chevron: {
+    flexShrink: 0,
+  },
+  newDot: {
+    position: 'absolute',
+    top: Spacing.md,
+    right: Spacing.xxxl,       // ChevronRight 좌측
+    width: 6,
+    height: 6,
+    borderRadius: Radii.full,
+    backgroundColor: Colors.primary.electricCyan,
   },
 });

--- a/mirror-soul/src/components/home/history/parts/HistoryCallCard/CallProfile.tsx
+++ b/mirror-soul/src/components/home/history/parts/HistoryCallCard/CallProfile.tsx
@@ -1,142 +1,82 @@
-import {Colors, Radii, FontFamily, FontSize, FontWeight, Spacing} from '@/src/constants/theme';
-import { useThemeColors } from '@/src/hooks/useThemeColors';
-import { LinearGradient } from 'expo-linear-gradient';
 import React from 'react';
 import { Image, StyleSheet, Text, View } from 'react-native';
+import { Colors, FontFamily, FontSize, FontWeight, Radii, Spacing } from '@/src/constants/theme';
+import { Feather } from '@expo/vector-icons';
 
-export interface CallProfileProps {
+interface CallAvatarProps {
   name: string;
-  age: number;
-  consistencyPercent: number;
-  dateStr: string; // ex) "오늘", "어제", "10.24"
-  timeStr: string; // ex) "14:30"
   profileImageUrl?: string;
-  callTypeDesc: string; // ex) "내가 시작한 통화", "상대방이 시작한 통화"
+  direction: 'SENT' | 'RECEIVED';
 }
 
-export default function CallProfile({
-  name,
-  age,
-  consistencyPercent,
-  dateStr,
-  timeStr,
-  profileImageUrl,
-  callTypeDesc,
-}: CallProfileProps) {
-  const { colors } = useThemeColors();
+/**
+ * 통화 카드 아바타 컴포넌트 (SRP)
+ * 프로필 이미지(또는 이니셜) + 우하단 방향 배지를 렌더링합니다.
+ * - RECEIVED(받음): electricCyan 배경 + arrow-down-left
+ * - SENT(보냄): vividPurple 배경 + arrow-up-right
+ */
+export default function CallAvatar({ name, profileImageUrl, direction }: CallAvatarProps) {
+  const isReceived = direction === 'RECEIVED';
+  const badgeColor = isReceived ? Colors.primary.electricCyan : Colors.primary.vividPurple;
+  const arrowIcon = isReceived ? 'arrow-down-left' : 'arrow-up-right';
 
   return (
-    <View style={styles.container}>
-      {/* Profile Image */}
-      <View style={styles.profileImageWrapper}>
-        {profileImageUrl ? (
-          <Image source={{ uri: profileImageUrl }} style={[styles.profileImage, { borderColor: colors.border.primary, borderWidth: 1 }]} />
-        ) : (
-          <View style={[styles.profileImage, { backgroundColor: colors.background.glass, borderColor: colors.border.primary, borderWidth: 1 }]} />
-        )}
-      </View>
-
-      {/* Info Section */}
-      <View style={styles.infoWrapper}>
-        <View style={styles.nameAgeRow}>
-          <Text style={[styles.nameAgeText, { color: colors.text.primary }]}>{name}, {age}</Text>
-          <View style={styles.consistencyBadgeWrapper}>
-            <LinearGradient
-              colors={[Colors.glass.cyan20, Colors.glass.purple20]}
-              start={{ x: 0, y: 0.5 }}
-              end={{ x: 1, y: 0.5 }}
-              style={styles.consistencyBadge}
-            >
-              <Text style={[styles.consistencyText, { color: colors.text.primary }]}>{consistencyPercent}%</Text>
-            </LinearGradient>
-          </View>
+    <View style={styles.wrapper}>
+      {/* 프로필 이미지 또는 이니셜 */}
+      {profileImageUrl ? (
+        <Image source={{ uri: profileImageUrl }} style={styles.avatar} />
+      ) : (
+        <View style={styles.avatarPlaceholder}>
+          <Text style={styles.initialText}>{name[0]}</Text>
         </View>
-        <Text style={[styles.typeDescText, { color: colors.text.secondary }]}>{callTypeDesc}</Text>
-      </View>
+      )}
 
-      {/* Date / Time */}
-      <View style={styles.dateWrapper}>
-        <Text style={[styles.dateText, { color: colors.text.secondary }]}>{dateStr}</Text>
-        <Text style={[styles.timeText, { color: colors.text.muted }]}>{timeStr}</Text>
+      {/* 방향 배지 */}
+      <View style={[styles.badge, { backgroundColor: badgeColor }]}>
+        <Feather name={arrowIcon} size={10} color={Colors.primary.soulBlack} />
       </View>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.md,
-    alignSelf: 'stretch',
-  },
-  profileImageWrapper: {
+  wrapper: {
     width: 48,
     height: 48,
+    position: 'relative',
+    flexShrink: 0,
   },
-  profileImage: {
+  avatar: {
     width: 48,
     height: 48,
     borderRadius: Radii.full,
   },
-  infoWrapper: {
-    flex: 1,
-    flexDirection: 'column',
-    gap: Spacing.xs,
-  },
-  nameAgeRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.sm,
-  },
-  nameAgeText: {
-    fontFamily: FontFamily.sans,
-    fontSize: FontSize.xl,
-    fontWeight: FontWeight.medium,
-    lineHeight: 27, // 150%
-    letterSpacing: -0.439,
-  },
-  consistencyBadgeWrapper: {
+  avatarPlaceholder: {
+    width: 48,
+    height: 48,
     borderRadius: Radii.full,
+    backgroundColor: Colors.glass.white10,
     borderWidth: 0.612,
-    borderColor: Colors.glass.cyan30_d3,
-    overflow: 'hidden',
-  },
-  consistencyBadge: {
-    paddingHorizontal: 8.6,
-    paddingVertical: 3.5, // 근사치 4.4 - 0.6 = 3.8
+    borderColor: Colors.glass.white15,
     justifyContent: 'center',
     alignItems: 'center',
   },
-  consistencyText: {
+  initialText: {
+    color: Colors.neutral.lightGrayText,
     fontFamily: FontFamily.sans,
-    fontSize: FontSize.sm,
-    fontWeight: FontWeight.regular,
-    lineHeight: 16, // 133.333%
+    fontSize: FontSize.lg,
+    fontWeight: FontWeight.bold,
   },
-  typeDescText: {
-    fontFamily: FontFamily.sans,
-    fontSize: FontSize.sm,
-    fontWeight: FontWeight.regular,
-    lineHeight: 16,
-  },
-  dateWrapper: {
-    flexDirection: 'column',
-    alignItems: 'flex-end',
-    gap: Spacing.xs,
-  },
-  dateText: {
-    fontFamily: FontFamily.sans,
-    fontSize: FontSize.sm,
-    fontWeight: FontWeight.regular,
-    lineHeight: 16,
-    textAlign: 'right',
-  },
-  timeText: {
-    fontFamily: FontFamily.sans,
-    fontSize: FontSize.sm,
-    fontWeight: FontWeight.regular,
-    lineHeight: 16,
-    textAlign: 'right',
+  badge: {
+    position: 'absolute',
+    bottom: -2,
+    right: -2,
+    width: 20,
+    height: 20,
+    borderRadius: Radii.sm,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderWidth: 1.5,
+    borderColor: Colors.primary.soulBlack,
   },
 });

--- a/mirror-soul/src/components/home/history/parts/HistoryCallCard/CallSubInfo.tsx
+++ b/mirror-soul/src/components/home/history/parts/HistoryCallCard/CallSubInfo.tsx
@@ -1,58 +1,135 @@
-import HistoryIcon from '@/assets/images/common/bottomNavbar/History_button.svg';
-import PurpleHeartIcon from '@/assets/images/common/history/purpleHeart.svg';
-import {Colors, Radii, FontFamily, FontSize, FontWeight, Spacing} from '@/src/constants/theme';
-import { useThemeColors } from '@/src/hooks/useThemeColors';
 import React from 'react';
-import { StyleSheet, View, Text } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors, FontFamily, FontSize, FontWeight, Radii, Spacing } from '@/src/constants/theme';
+import { useThemeColors } from '@/src/hooks/useThemeColors';
 
-export interface CallSubInfoProps {
-  durationLabel: string; // ex) "8분 23초"
-  twinMatchLabel: string; // ex) "상대 Twin 92%"
+interface CallMetaProps {
+  name: string;
+  age: number;
+  consistencyPercent: number;
+  timeStr: string;
+  durationLabel: string;
+  tags: string[];
 }
 
-export default function CallSubInfo({
+/** 태그 chip 최대 표시 개수 */
+const MAX_TAGS = 3;
+
+/**
+ * 통화 카드 메타 정보 컴포넌트 (SRP)
+ * 이름/나이, 시간, 일치도%, 통화시간, 주제 태그를 렌더링합니다.
+ * CallSubInfo + CallTagRow를 하나의 관심사로 통합합니다.
+ */
+export default function CallMeta({
+  name,
+  age,
+  consistencyPercent,
+  timeStr,
   durationLabel,
-  twinMatchLabel,
-}: CallSubInfoProps) {
+  tags,
+}: CallMetaProps) {
   const { colors } = useThemeColors();
 
   return (
     <View style={styles.container}>
-      {/* Time */}
-      <View style={[styles.chip, { backgroundColor: colors.background.glass, borderColor: colors.border.primary }]}>
-        <HistoryIcon width={16} height={16} color={colors.text.muted} />
-        <Text style={[styles.chipText, { color: colors.text.muted }]}>{durationLabel}</Text>
+      {/* Row 1: 이름·나이 (좌) / 시간 (우) */}
+      <View style={styles.row}>
+        <Text style={[styles.nameText, { color: colors.text.primary }]} numberOfLines={1}>
+          {name},{' '}
+          <Text style={[styles.ageText, { color: colors.text.muted }]}>{age}</Text>
+        </Text>
+        <Text style={[styles.timeText, { color: colors.text.muted }]}>{timeStr}</Text>
       </View>
 
-      {/* Twin Match */}
-      <View style={[styles.chip, { backgroundColor: colors.background.glass, borderColor: colors.border.primary }]}>
-        <PurpleHeartIcon width={16} height={16} />
-        <Text style={[styles.chipText, { color: colors.text.muted }]}>{twinMatchLabel}</Text>
+      {/* Row 2: 일치도% + 통화시간 */}
+      <View style={styles.row}>
+        <View style={styles.metaItem}>
+          <Feather name="zap" size={10} color={Colors.primary.electricCyan} />
+          <Text style={styles.consistencyText}>{consistencyPercent}%</Text>
+        </View>
+        <View style={styles.metaItem}>
+          <Feather name="clock" size={10} color={colors.text.muted} />
+          <Text style={[styles.durationText, { color: colors.text.muted }]}>{durationLabel}</Text>
+        </View>
       </View>
+
+      {/* Row 3: 주제 태그 chips (최대 MAX_TAGS개) */}
+      {tags.length > 0 && (
+        <View style={styles.tagsRow}>
+          {tags.slice(0, MAX_TAGS).map((tag, index) => (
+            <View key={index} style={styles.tagChip}>
+              <Text style={styles.tagText}>{tag}</Text>
+            </View>
+          ))}
+        </View>
+      )}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: Spacing.md, // 11.992px
-    alignSelf: 'stretch',
+    flex: 1,
+    flexDirection: 'column',
+    gap: Spacing.xxs,
+    minWidth: 0, // 텍스트 truncation을 위한 flex 레이아웃 보정
   },
-  chip: {
-    flex: 1, // 균등 분할
+  row: {
     flexDirection: 'row',
-    height: 32, // 31.988px
-    paddingHorizontal: Spacing.sm,
     alignItems: 'center',
+    justifyContent: 'space-between',
     gap: Spacing.sm,
-    borderRadius: Radii.smmd, // 10px (스펙에서 새로 추가함)
   },
-  chipText: {
+  nameText: {
     fontFamily: FontFamily.sans,
-    fontSize: FontSize.sm,
+    fontSize: FontSize.base,
+    fontWeight: FontWeight.semibold,
+    letterSpacing: -0.15,
+    flex: 1,
+  },
+  ageText: {
     fontWeight: FontWeight.regular,
-    lineHeight: 16, // 133.333%
+  },
+  timeText: {
+    fontFamily: FontFamily.mono,
+    fontSize: FontSize.xs,
+    flexShrink: 0,
+  },
+  metaItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.xxs,
+  },
+  consistencyText: {
+    fontFamily: FontFamily.sans,
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.bold,
+    color: Colors.primary.electricCyan,
+  },
+  durationText: {
+    fontFamily: FontFamily.sans,
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.bold,
+  },
+  tagsRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: Spacing.xs,
+    marginTop: Spacing.xxs,
+  },
+  tagChip: {
+    paddingHorizontal: Spacing.sm,
+    paddingVertical: Spacing.xxs,
+    borderRadius: Radii.sm,
+    borderWidth: 0.612,
+    borderColor: Colors.glass.purple20,
+    backgroundColor: Colors.glass.purple10,
+  },
+  tagText: {
+    color: Colors.primary.vividPurple,
+    fontFamily: FontFamily.sans,
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.regular,
   },
 });

--- a/mirror-soul/src/components/home/history/parts/HistoryCallCard/CallTagRow.tsx
+++ b/mirror-soul/src/components/home/history/parts/HistoryCallCard/CallTagRow.tsx
@@ -1,6 +1,12 @@
+/**
+ * @deprecated CallTagRow는 CallMeta (CallSubInfo.tsx)로 통합되었습니다.
+ * DRY 원칙에 따라 태그 렌더링 로직을 단일 위치로 통합했습니다.
+ * 이 파일은 참조용으로 유지되며, 직접 import하여 사용하지 마세요.
+ */
 import {Colors, Radii, FontFamily, FontSize, FontWeight, Spacing} from '@/src/constants/theme';
 import { useThemeColors } from '@/src/hooks/useThemeColors';
 import React from 'react';
+
 import { StyleSheet, Text, View } from 'react-native';
 
 export interface CallTagRowProps {

--- a/mirror-soul/src/components/home/history/parts/HistoryDateSectionHeader.tsx
+++ b/mirror-soul/src/components/home/history/parts/HistoryDateSectionHeader.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { Colors, FontFamily, FontSize, FontWeight, Spacing } from '@/src/constants/theme';
+import { useThemeColors } from '@/src/hooks/useThemeColors';
+
+interface HistoryDateSectionHeaderProps {
+  dateLabel: string;
+}
+
+/**
+ * 날짜 섹션 구분 헤더 컴포넌트 (SRP)
+ * 날짜 레이블 좌측 + 우측 얇은 수평 구분선으로 구성됩니다.
+ */
+export default function HistoryDateSectionHeader({ dateLabel }: HistoryDateSectionHeaderProps) {
+  const { colors } = useThemeColors();
+
+  return (
+    <View style={styles.container}>
+      <Text style={[styles.dateLabel, { color: colors.text.muted }]}>{dateLabel}</Text>
+      <View style={[styles.divider, { backgroundColor: colors.border.primary }]} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.md,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.xs,
+  },
+  dateLabel: {
+    fontFamily: FontFamily.sans,
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.black as any,
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
+    flexShrink: 0,
+  },
+  divider: {
+    flex: 1,
+    height: StyleSheet.hairlineWidth,
+  },
+});

--- a/mirror-soul/src/components/home/history/parts/HistoryFilterButton.tsx
+++ b/mirror-soul/src/components/home/history/parts/HistoryFilterButton.tsx
@@ -1,7 +1,7 @@
-import {Colors, Radii, FontFamily, FontSize, FontWeight} from '@/src/constants/theme';
-import { useThemeColors } from '@/src/hooks/useThemeColors';
 import React from 'react';
 import { StyleSheet, TouchableOpacity, Text } from 'react-native';
+import { Colors, FontFamily, FontSize, FontWeight, Radii, Spacing } from '@/src/constants/theme';
+import { useThemeColors } from '@/src/hooks/useThemeColors';
 
 export interface HistoryFilterButtonProps {
   label: string;
@@ -11,6 +11,7 @@ export interface HistoryFilterButtonProps {
 
 /**
  * 리스트 필터용 개별 버튼 (SRP)
+ * 컴팩트 pill 버튼 스타일 — 콘텐츠 너비에 맞게 자동 조절됩니다.
  */
 export default function HistoryFilterButton({
   label,
@@ -23,16 +24,21 @@ export default function HistoryFilterButton({
     <TouchableOpacity
       style={[
         styles.container,
-        isActive 
-          ? { backgroundColor: colors.background.card, borderColor: colors.border.primary } 
-          : { backgroundColor: colors.background.glass, borderColor: colors.border.primary },
+        isActive
+          ? { backgroundColor: colors.background.card, borderColor: colors.border.primary }
+          : { backgroundColor: 'transparent', borderColor: 'transparent' },
       ]}
       onPress={onPress}
       activeOpacity={0.7}
       accessibilityRole="button"
       accessibilityState={{ selected: isActive }}
     >
-      <Text style={[styles.label, isActive ? { color: colors.text.primary } : { color: colors.text.muted }]}>
+      <Text
+        style={[
+          styles.label,
+          isActive ? { color: colors.text.primary } : { color: colors.text.muted },
+        ]}
+      >
         {label}
       </Text>
     </TouchableOpacity>
@@ -41,19 +47,19 @@ export default function HistoryFilterButton({
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1, // 버튼들이 동일한 비율로 너비를 가짐
-    paddingVertical: 10,
+    paddingHorizontal: Spacing.md,
     justifyContent: 'center',
     alignItems: 'center',
-    borderRadius: Radii.md2, // 14px
+    borderRadius: Radii.md,
     borderWidth: 0.612,
+    height: '100%',
   },
   label: {
     fontFamily: FontFamily.sans,
-    fontSize: FontSize.base,
-    fontWeight: FontWeight.medium,
-    lineHeight: 20, // 142.857%
-    letterSpacing: -0.15,
+    fontSize: FontSize.xs,
+    fontWeight: FontWeight.black as any,
+    letterSpacing: 0.8,
+    textTransform: 'uppercase',
     textAlign: 'center',
   },
 });

--- a/mirror-soul/src/components/home/history/parts/HistorySearchBar.tsx
+++ b/mirror-soul/src/components/home/history/parts/HistorySearchBar.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { StyleSheet, TextInput, View } from 'react-native';
+import { Feather } from '@expo/vector-icons';
+import { Colors, FontFamily, FontSize, Radii, Spacing } from '@/src/constants/theme';
+import { useThemeColors } from '@/src/hooks/useThemeColors';
+
+interface HistorySearchBarProps {
+  value: string;
+  onChangeText: (text: string) => void;
+  placeholder?: string;
+}
+
+/**
+ * 통화 기록 검색 인풋 컴포넌트 (SRP)
+ * 포커스 시 electricCyan 테두리로 강조합니다.
+ */
+export default function HistorySearchBar({
+  value,
+  onChangeText,
+  placeholder = '대화 내용 검색',
+}: HistorySearchBarProps) {
+  const { colors } = useThemeColors();
+  const [isFocused, setIsFocused] = React.useState(false);
+
+  return (
+    <View
+      style={[
+        styles.container,
+        { backgroundColor: colors.background.glass, borderColor: isFocused ? Colors.primary.electricCyan : colors.border.primary },
+      ]}
+    >
+      <Feather
+        name="search"
+        size={14}
+        color={isFocused ? Colors.primary.electricCyan : colors.text.muted}
+        style={styles.icon}
+      />
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor={colors.text.muted}
+        onFocus={() => setIsFocused(true)}
+        onBlur={() => setIsFocused(false)}
+        style={[styles.input, { color: colors.text.primary }]}
+        returnKeyType="search"
+        clearButtonMode="while-editing"
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    height: 48,
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: Radii.lg,
+    borderWidth: 0.612,
+    paddingHorizontal: Spacing.md,
+    gap: Spacing.sm,
+  },
+  icon: {
+    flexShrink: 0,
+  },
+  input: {
+    flex: 1,
+    fontFamily: FontFamily.sans,
+    fontSize: FontSize.sm,
+    padding: 0, // iOS 기본 패딩 제거
+  },
+});

--- a/mirror-soul/src/components/signup/steps/Step1_Account/components/EmailVerificationModal.tsx
+++ b/mirror-soul/src/components/signup/steps/Step1_Account/components/EmailVerificationModal.tsx
@@ -10,6 +10,8 @@ import Animated, {
   withTiming
 } from 'react-native-reanimated';
 import { VerificationModalProps } from '../types/step1';
+import { useThemeColors } from '@/src/hooks/useThemeColors';
+
 
 const { height: SCREEN_HEIGHT } = Dimensions.get('window');
 

--- a/mirror-soul/src/mocks/historyMocks.ts
+++ b/mirror-soul/src/mocks/historyMocks.ts
@@ -18,6 +18,8 @@ export const MOCK_CALL_HISTORY: HistoryCallItemData[] = [
     durationLabel: '8분 23초',
     twinMatchLabel: '상대 Twin 92%',
     tags: ['음악', '전시회', '크리에이티브'],
+    isNew: true,
+    satisfactionPercent: 92,
     messages: [
       {
         id: 'm1',
@@ -64,13 +66,15 @@ export const MOCK_CALL_HISTORY: HistoryCallItemData[] = [
     age: 26,
     consistencyPercent: 88,
     callSequenceNumber: 1,
-    dateStr: '어제',
-    timeStr: '21:15',
+    dateStr: '오늘',
+    timeStr: '11:15',
     direction: 'RECEIVED',
     callTypeDesc: '상대방이 시작한 통화',
     durationLabel: '12분 40초',
     twinMatchLabel: '상대 Twin 85%',
     tags: ['여행', '맛집'],
+    isNew: true,
+    satisfactionPercent: 88,
     messages: [
       {
         id: 'm1',
@@ -86,4 +90,63 @@ export const MOCK_CALL_HISTORY: HistoryCallItemData[] = [
       },
     ],
   },
+  {
+    id: '3',
+    name: '예진',
+    age: 29,
+    consistencyPercent: 87,
+    callSequenceNumber: 3,
+    dateStr: '어제',
+    timeStr: '19:20',
+    direction: 'SENT',
+    callTypeDesc: '내가 시작한 통화',
+    durationLabel: '15분 10초',
+    twinMatchLabel: '상대 Twin 95%',
+    tags: ['여행 기록', '사진', '긍정 에너지'],
+    isNew: false,
+    satisfactionPercent: 95,
+    messages: [
+      {
+        id: 'm1',
+        direction: 'RECEIVED',
+        text: '안녕하세요! 예진이에요.',
+        timestamp: '19:20',
+      },
+    ],
+  },
+  {
+    id: '4',
+    name: '수빈',
+    age: 28,
+    consistencyPercent: 94,
+    callSequenceNumber: 1,
+    dateStr: '어제',
+    timeStr: '16:45',
+    direction: 'RECEIVED',
+    callTypeDesc: '상대방이 시작한 통화',
+    durationLabel: '6분 30초',
+    twinMatchLabel: '상대 Twin 90%',
+    tags: ['책', '갤러리', '창의적인 생각'],
+    isNew: false,
+    satisfactionPercent: 90,
+    messages: [
+      {
+        id: 'm1',
+        direction: 'RECEIVED',
+        text: '안녕하세요! 오늘 전시 어떠셨어요?',
+        timestamp: '16:45',
+      },
+    ],
+  },
 ];
+
+/**
+ * 주간 통계 Mock 데이터 (임시 — API 연동 시 제거)
+ * HistoryStatsRow에서 사용합니다.
+ */
+export const MOCK_WEEKLY_STATS = {
+  totalHours: 12.5,
+  received: 8,
+  sent: 4,
+  weeklyGrowthPercent: 12,
+} as const;


### PR DESCRIPTION
## 💡 작업 동기 및 목적
- **디자인 레퍼런스 싱크 및 UI 전면 개편**: 기존 History 화면(`app/(main)/history.tsx`) 및 통화 상세 화면(`app/call-detail.tsx`)의 UI를 새로운 Web 레퍼런스 디자인에 맞추어 고밀도/고품질 디자인으로 전면 리팩터링했습니다.
- **설계 원칙 강화**: 기존 하드코딩된 스타일을 배제하고 디자인 시스템 토큰을 엄격하게 적용했으며, **SoC(관심사 분리), SoP(프로토콜 분리), SOLID, DRY, KISS** 원칙을 준수하여 컴포넌트 구조를 완전히 재설계했습니다.
- **연관 이슈**: Close #115

<br />

## 📝 변경 사항

### 1. 탭/화면 컴포넌트 아키텍처 재설계
기존의 파편화된 컴포넌트 역할을 명확히 분리하고 SRP(단일 책임 원칙)에 따라 쪼개어 조립하는 방식으로 변경했습니다.

- **[x] `HistoryHeader` 레이아웃 개편**
  - 단순 타이틀에서 **3-slot 레이아웃**(아바타 버튼 - 타이틀 - 설정 버튼)으로 변경했습니다.
- **[x] `HistoryStatsRow` (Weekly Summary) 통합**
  - 기존 3개로 분리되어 있던 카드를 **단일 Wide 카드** 하나로 통합하여 가독성을 높였습니다. (누적 대화 시간, 주간 증가율 배지, 받음/보냄 가로 정렬 배치)
- **[x] 검색 및 필터 UI 개선 (`HistoryFilterRow` & `HistorySearchBar`)**
  - 검색 인풋창을 분리(`HistorySearchBar`)하고, 기존 꽉 차던 필터 버튼(`HistoryFilterButton`)을 컴팩트한 pill 형태로 수정했습니다.
  - **UX 개선**: 검색창과 필터 컨테이너 높이를 48px로 맞추고 터치 영역(padding)을 넓혀 터치 사용성을 강화했습니다.
- **[x] `HistoryList`의 `SectionList` 마이그레이션**
  - 단순 FlatList에서 날짜(`dateStr`) 단위로 그룹핑을 제공하는 `SectionList`로 변경했습니다.
  - 이름 및 태그 텍스트 기반의 **로컬 검색 필터링** 로직을 추가했습니다.
- **[x] `HistoryCallCard` 고밀도 UI로 압축**
  - 기존 3행(Profile, SubInfo, TagRow) 레이아웃을 1행으로 압축하여 정보 밀도를 높였습니다.
  - 내부 로직을 `CallAvatar`(아바타+방향 배지)와 `CallMeta`(이름/시간/유사도/태그 통합) 2개의 하위 컴포넌트로 분리했습니다.
  - `isNew` 상태일 경우 테두리 글로우 효과 및 우상단 Cyan Dot 인디케이터가 렌더링 됩니다.

### 2. 통화 상세 화면 (`call-detail.tsx`) 개편
- **[x] 읽기 전용 뷰로 책임 명확화 (SoC)**
  - 실시간 채팅 기능은 `/message-room` 라우트로 책임을 이관하고, 해당 화면은 **통화 기록 열람 및 Twin 답변 수정 전용 화면**으로 확정지었습니다.
- **[x] 채팅형 헤더 (`CallDetailHeader`) 도입**
  - 아바타, 유사도, 온라인 상태, 전화/더보기 아이콘이 포함된 채팅 앱 스타일의 헤더로 전면 교체했습니다.
- **[x] 배너 및 푸터 시각화 강화**
  - 기존 편집 안내 얼럿을 "유사도 힌트 배너(`CallDetailAlert`)"로 교체하고, `CallDetailFooter`를 Pill 뱃지 스타일로 시각을 강화했습니다.

<br />

### 🏗 컴포넌트 아키텍처 변화 (Mermaid)

```mermaid
graph TD
    subgraph AS-IS
        A1[history.tsx] --> B1[HistoryStatsRow<br>3개 카드 분리]
        A1 --> C1[HistoryFilterRow<br>전체너비 버튼]
        A1 --> D1[HistoryList<br>FlatList]
        D1 --> E1[HistoryCallCard]
        E1 --> F1[CallProfile]
        E1 --> G1[CallSubInfo]
        E1 --> H1[CallTagRow]
    end

    subgraph TO-BE
        A2[history.tsx] --> B2[HistoryStatsRow<br>단일 통합 카드]
        A2 --> C2[HistoryFilterRow<br>검색+컴팩트필터]
        C2 -.-> C2_1[HistorySearchBar NEW]
        A2 --> D2[HistoryList<br>SectionList]
        D2 -.-> D2_1[HistoryDateSectionHeader NEW]
        D2 --> E2[HistoryCallCard<br>단일 Row 압축]
        E2 --> F2[CallAvatar<br>프로필+방향배지]
        E2 --> G2[CallMeta<br>정보+태그 통합]
    end

    AS-IS ~~~ TO-BE
```

<br />

## 📸 스크린샷 (선택)

<br />

## 🧐 리뷰 포인트 / 기타 특이사항

1. **상태 관리 및 검색 최적화**
   - 검색어(`searchQuery`)와 필터(`activeFilter`)가 변경될 때마다 `SectionList`의 그룹핑 연산이 발생합니다. 이를 최적화하기 위해 `HistoryList` 내부에서 `useMemo`를 통해 필터링/그룹핑 데이터 트랜스폼을 수행하도록 구현했습니다.
2. **채팅 기능 분리 결정 (SoC)**
   - 레퍼런스 디자인에는 하단 메시지 입력 UI가 포함되어 있었으나, 해당 화면(`call-detail`)은 "과거 기록 열람"의 역할에 충실하기 위해 **실시간 채팅 입력창을 의도적으로 배제**했습니다. 실시간 통신은 기존 `/message-room` 라우트에서 처리하는 것이 맞다고 판단했습니다.
3. **태그 렌더링 로직 통합 (DRY)**
   - 기존의 `CallTagRow.tsx`는 과도하게 분리되어 오히려 코드 중복을 야기했습니다. 이를 `CallMeta.tsx` 컴포넌트 내부로 병합하여 DRY 원칙을 준수했습니다. 기존 `CallTagRow.tsx`는 추후 참조를 위해 `@deprecated` 주석을 달아두었습니다. 
4. **디자인 토큰 준수**
   - 색상, 폰트, 간격, 둥글기 등 모든 UI 요소에서 하드코딩을 걷어내고 `theme.ts`(`Colors`, `Radii`, `Spacing` 등)만을 사용하여 작성했습니다. 향후 다크모드/라이트모드 스위칭에 완벽히 대응합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 통화 기록에 검색 기능이 추가되었습니다.
  * 방향 필터와 검색어를 함께 적용할 수 있습니다.
  * 통화 기록을 날짜별로 그룹화해 표시합니다.
  * 주간 요약 통계(누적 대화 시간, 성장률)와 상세 표시가 제공됩니다.
  * 통화 상세 화면에 유사도 힌트 및 통화·더보기 버튼이 추가되었습니다.
* **개선 사항**
  * 검색 결과가 없을 때 안내 메시지가 표시됩니다.
  * 통화 기록 카드/태그/메타 및 프로필·설정 헤더 UI가 새로워졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->