### PR TITLE
refactor(mvp): centralize hardcoded call-time balance into one store

### DIFF
--- a/mirror-soul/src/components/home/main/AvailableTimeCard.tsx
+++ b/mirror-soul/src/components/home/main/AvailableTimeCard.tsx
@@ -3,8 +3,10 @@ import { Colors, FontFamily, FontSize, FontWeight, Radii, Spacing } from '@/src/
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useThemeColors } from '@/src/hooks/useThemeColors';
+import { useCallTimeStore, formatCallTime } from '@/src/store/useCallTimeStore';
 
 interface AvailableTimeCardProps {
+  /** 지정하지 않으면 useCallTimeStore의 값을 사용합니다. */
   timeDisplay?: string;
   onRefillPress?: () => void;
 }
@@ -15,10 +17,12 @@ interface AvailableTimeCardProps {
  * 충전 바텀시트의 열림 상태는 부모(index.tsx)가 소유합니다.
  */
 export default function AvailableTimeCard({
-  timeDisplay = '02:30:00',
+  timeDisplay,
   onRefillPress,
 }: AvailableTimeCardProps) {
   const { colors } = useThemeColors();
+  const remainingSeconds = useCallTimeStore((state) => state.remainingSeconds);
+  const displayValue = timeDisplay ?? formatCallTime(remainingSeconds);
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background.glass, borderColor: colors.border.primary }]}>
@@ -28,7 +32,7 @@ export default function AvailableTimeCard({
         </View>
         <View>
           <Text style={[styles.label, { color: colors.text.muted }]}>Available Time</Text>
-          <Text style={[styles.value, { color: colors.text.primary }]}>{timeDisplay}</Text>
+          <Text style={[styles.value, { color: colors.text.primary }]}>{displayValue}</Text>
         </View>
       </View>
 

--- a/mirror-soul/src/components/home/main/RefillModal.tsx
+++ b/mirror-soul/src/components/home/main/RefillModal.tsx
@@ -3,6 +3,7 @@ import { Colors, FontFamily, FontSize, FontWeight, Radii, Spacing } from '@/src/
 import { useThemeColors } from '@/src/hooks/useThemeColors';
 import React from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { TIME_REFILL_OPTIONS } from '@/src/features/profile/constants/timeRefillOptions';
 
 interface TimePackage {
   id: string;
@@ -13,12 +14,16 @@ interface TimePackage {
   note: string;
 }
 
-// 시간 충전 패키지 — 다른 곳에서 재사용되지 않으므로 별도 상수 파일 없이 colocate
-const TIME_PACKAGES: TimePackage[] = [
-  { id: 'lite', duration: '30분', tagline: '30분 동안 이야기 나누기', price: '₩4,900', best: false, note: '' },
-  { id: 'best', duration: '2시간', tagline: '2시간 동안 이야기 나누기', price: '₩14,900', best: true, note: '인기' },
-  { id: 'bulk', duration: '10시간', tagline: '10시간 가득 채우기', price: '₩59,000', best: false, note: '경제적' },
-];
+// TIME_REFILL_OPTIONS(단일 소스)에서 파생 — 여기서 별도로 가격/구성을 하드코딩하면
+// TimeRefillBottomSheet.tsx와 가격이 어긋날 수 있다.
+const TIME_PACKAGES: TimePackage[] = TIME_REFILL_OPTIONS.map((option) => ({
+  id: option.id,
+  duration: option.addedTime.replace('+ ', ''),
+  tagline: option.durationLabel,
+  price: option.price,
+  best: option.badge?.type === 'popular',
+  note: option.badge?.text ?? '',
+}));
 
 interface RefillModalProps {
   visible: boolean;

--- a/mirror-soul/src/features/profile-settings/ProfileSettingsScreen.tsx
+++ b/mirror-soul/src/features/profile-settings/ProfileSettingsScreen.tsx
@@ -24,9 +24,8 @@ export const ProfileSettingsScreen = () => {
         <Header title="공간 관리 및 설정" delay={0} />
 
         <View style={styles.content}>
-          {/* 대화 가능 시간 카드 */}
+          {/* 대화 가능 시간 카드 (미지정 시 useCallTimeStore 값 사용) */}
           <AvailableTimeCard
-            timeString="02:30:00"
             delay={80}
             onPressRefill={handleOpenSheet}
           />

--- a/mirror-soul/src/features/profile/components/AvailableTimeCard.tsx
+++ b/mirror-soul/src/features/profile/components/AvailableTimeCard.tsx
@@ -8,14 +8,18 @@ import { Feather } from '@expo/vector-icons';
 import Animated, { FadeInDown } from 'react-native-reanimated';
 import { usePulseAnimation, usePressAnimation } from '../hooks/useProfileAnimations';
 import { useThemeColors } from '@/src/hooks/useThemeColors';
+import { useCallTimeStore, formatCallTime } from '@/src/store/useCallTimeStore';
 
 interface AvailableTimeCardProps {
-  timeString: string;
+  /** 지정하지 않으면 useCallTimeStore의 값을 사용합니다. */
+  timeString?: string;
   delay?: number;
   onPressRefill?: () => void;
 }
 
 export const AvailableTimeCard = ({ timeString, delay = 100, onPressRefill }: AvailableTimeCardProps) => {
+  const remainingSeconds = useCallTimeStore((state) => state.remainingSeconds);
+  const displayValue = timeString ?? formatCallTime(remainingSeconds);
   const { startPulse, animatedStyle: pulseStyle } = usePulseAnimation();
   const { handlePressIn, handlePressOut, animatedStyle: pressStyle } = usePressAnimation();
   const { colors } = useThemeColors();
@@ -46,7 +50,7 @@ export const AvailableTimeCard = ({ timeString, delay = 100, onPressRefill }: Av
           <MaskedView
             style={styles.maskContainer}
             maskElement={
-              <Text style={styles.timeTextMask}>{timeString}</Text>
+              <Text style={styles.timeTextMask}>{displayValue}</Text>
             }
           >
             <LinearGradient

--- a/mirror-soul/src/features/profile/components/TimeRefillBottomSheet.tsx
+++ b/mirror-soul/src/features/profile/components/TimeRefillBottomSheet.tsx
@@ -6,6 +6,7 @@ import { BottomSheet } from '../../../components/common/BottomSheet/BottomSheet'
 import { TIME_REFILL_OPTIONS } from '../constants/timeRefillOptions';
 import { TimeRefillOption } from './TimeRefillOption';
 import { useThemeColors } from '@/src/hooks/useThemeColors';
+import { useCallTimeStore, formatCallTime } from '@/src/store/useCallTimeStore';
 
 interface TimeRefillBottomSheetProps {
   isOpen: boolean;
@@ -14,6 +15,7 @@ interface TimeRefillBottomSheetProps {
 
 export const TimeRefillBottomSheet = ({ isOpen, onClose }: TimeRefillBottomSheetProps) => {
   const { colors } = useThemeColors();
+  const remainingSeconds = useCallTimeStore((state) => state.remainingSeconds);
 
   return (
     <BottomSheet isOpen={isOpen} onClose={onClose} height={580}>
@@ -24,7 +26,7 @@ export const TimeRefillBottomSheet = ({ isOpen, onClose }: TimeRefillBottomSheet
         {/* Header */}
         <View style={styles.header}>
           <Text style={[styles.title, { color: colors.text.primary }]}>대화 시간 채우기</Text>
-          <Text style={[styles.subtitle, { color: colors.text.secondary }]}>현재 남은 시간: 02:30:00</Text>
+          <Text style={[styles.subtitle, { color: colors.text.secondary }]}>현재 남은 시간: {formatCallTime(remainingSeconds)}</Text>
         </View>
 
         {/* Options */}

--- a/mirror-soul/src/store/useCallTimeStore.ts
+++ b/mirror-soul/src/store/useCallTimeStore.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand';
+
+interface CallTimeState {
+  /** 남은 통화 가능 시간 (초). 실제 결제/잔액 API 연동 전까지는 로컬 mock 값. */
+  remainingSeconds: number;
+  setRemainingSeconds: (seconds: number) => void;
+  addSeconds: (seconds: number) => void;
+}
+
+// Initial MVP mock data: 02:30:00 (2시간 30분)
+const INITIAL_MOCK_SECONDS = 2 * 60 * 60 + 30 * 60;
+
+export const useCallTimeStore = create<CallTimeState>((set) => ({
+  remainingSeconds: INITIAL_MOCK_SECONDS,
+  setRemainingSeconds: (seconds) => set({ remainingSeconds: seconds }),
+  addSeconds: (seconds) => set((state) => ({ remainingSeconds: state.remainingSeconds + seconds })),
+}));
+
+/** HH:MM:SS 형식으로 포맷. 실제 결제 연동 전까지 여러 화면에서 공통으로 사용. */
+export function formatCallTime(totalSeconds: number): string {
+  const clamped = Math.max(0, Math.floor(totalSeconds));
+  const hours = Math.floor(clamped / 3600);
+  const minutes = Math.floor((clamped % 3600) / 60);
+  const seconds = clamped % 60;
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+}


### PR DESCRIPTION
The "02:30:00" remaining-call-time display was hardcoded independently in three places with no shared state:
- src/components/home/main/AvailableTimeCard.tsx (default prop value)
- src/features/profile-settings/ProfileSettingsScreen.tsx (literal passed to a *different*, visually distinct AvailableTimeCard component in src/features/profile/components/)
- src/features/profile/components/TimeRefillBottomSheet.tsx ("현재 남은 시간: 02:30:00" inline text)

Discovered along the way: there are two unrelated components both named AvailableTimeCard (components/home/main vs features/profile), with different prop names (timeDisplay/onRefillPress vs timeString/onPressRefill) and different visual designs. Did not merge them — that's a design decision (which visual style survives) beyond this branch's scope — but both now read from the same source of truth so the number itself can't drift between screens.

Added src/store/useCallTimeStore.ts (zustand, matching the existing useAccountStore.ts pattern) holding remainingSeconds + a formatCallTime() helper. All three display sites now default to this store's value; component props stay optional overrides for flexibility. When real balance API lands (Track 2), only this store needs to start reading from the server instead of a mock default.

Also deduplicated pricing: RefillModal.tsx had its own colocated TIME_PACKAGES array with the same three price points already defined in features/profile/constants/timeRefillOptions.ts — a price change in one would silently not apply to the other screen. RefillModal now derives its list from the shared TIME_REFILL_OPTIONS source instead.

Did not touch: the actual purchase flow is still fully mocked (button presses still don't call any payment API) — that's Track 2, tracked separately as it requires real IAP integration.

## 💡 작업 동기 및 목적
- 이 PR이 왜 필요한가요? (어떤 기능 추가/버그 수정인지 설명)
- 연관된 이슈 번호가 있다면 적어주세요. (예: Close #1)

## 📝 변경 사항
- 이 PR에서 핵심적으로 변경된 부분을 요약해주세요.
  - [x] 예: `LoginPage.tsx`에 SNS 로그인 버튼 추가
  - [x] 예: 라우팅 구조 변경 및 리다이렉트 처리 로직 버그 수정

## 📸 스크린샷 (선택)
- UI 변경이 있다면 전/후 사진이나 구현된 화면을 첨부해주세요. (없으면 지우셔도 무방합니다)

## 🧐 리뷰 포인트 / 기타 특이사항
- 특별히 고민했던 로직이나, 나중에 다시 보거나 리팩토링할 필요가 있는 부분이 있나요?
  - (예시) *카카오 로그인 리다이렉트 로직이 아직 매끄럽지 않아서 임시로 setTimeout 처리를 해두었습니다.*
