### PR TITLE
feat(mvp): wire up block/report as client-side interim safety features

### DIFF
--- a/mirror-soul/app/message-room/[id].tsx
+++ b/mirror-soul/app/message-room/[id].tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useLocalSearchParams } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import MessageRoomScreen from '@/src/features/message-room/MessageRoomScreen';
 import { MOCK_CHAT_ROOMS } from '@/src/mocks/messageMocks';
 import { Colors, FontFamily, FontSize, Spacing } from '@/src/constants/theme';
+import { isRoomBlocked } from '@/src/utils/blockList';
 
 /**
  * 메시지방 상세 화면 (루트 Stack 레벨)
@@ -14,13 +15,32 @@ import { Colors, FontFamily, FontSize, Spacing } from '@/src/constants/theme';
 export default function MessageRoomDetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const insets = useSafeAreaInsets();
+  const [blocked, setBlocked] = useState<boolean | null>(null);
 
   const room = MOCK_CHAT_ROOMS.find((r) => r.id === id);
+
+  useEffect(() => {
+    if (!room) return;
+    isRoomBlocked(room.id).then(setBlocked);
+  }, [room]);
 
   if (!room) {
     return (
       <View style={[styles.errorContainer, { paddingTop: insets.top }]}>
         <Text style={styles.errorText}>대화방을 찾을 수 없습니다.</Text>
+      </View>
+    );
+  }
+
+  // 차단 여부 확인 전에는 아무것도 그리지 않아 잠깐이라도 차단된 대화가 보이지 않게 한다.
+  if (blocked === null) {
+    return null;
+  }
+
+  if (blocked) {
+    return (
+      <View style={[styles.errorContainer, { paddingTop: insets.top }]}>
+        <Text style={styles.errorText}>차단한 대화 상대입니다.</Text>
       </View>
     );
   }

--- a/mirror-soul/src/features/message-room/MessageRoomScreen.tsx
+++ b/mirror-soul/src/features/message-room/MessageRoomScreen.tsx
@@ -122,6 +122,10 @@ export default function MessageRoomScreen({ room }: MessageRoomScreenProps) {
         room={room}
         isOpen={isPanelOpen}
         onClose={() => setIsPanelOpen(false)}
+        onBlocked={() => {
+          setIsPanelOpen(false);
+          router.back();
+        }}
       />
     </View>
   );

--- a/mirror-soul/src/features/message-room/components/MessageRoomOptionsPanel.tsx
+++ b/mirror-soul/src/features/message-room/components/MessageRoomOptionsPanel.tsx
@@ -26,6 +26,8 @@ interface MessageRoomOptionsPanelProps {
   room: ChatRoom;
   isOpen: boolean;
   onClose: () => void;
+  /** 차단 완료 후 호출 (대화방에서 나가기 등) */
+  onBlocked: () => void;
 }
 
 const PANEL_WIDTH = 280;
@@ -48,6 +50,7 @@ export default function MessageRoomOptionsPanel({
   room,
   isOpen,
   onClose,
+  onBlocked,
 }: MessageRoomOptionsPanelProps) {
   const { height: screenHeight } = useWindowDimensions();
   const insets = useSafeAreaInsets();
@@ -104,7 +107,7 @@ export default function MessageRoomOptionsPanel({
       >
         <OptionsProfileSection room={room} />
         <OptionsSettingsSection />
-        <OptionsDangerSection />
+        <OptionsDangerSection room={room} onBlocked={onBlocked} />
 
         {/* ─ 닫기 버튼 (하단 고정) ─ */}
         <View style={styles.closeSection}>

--- a/mirror-soul/src/features/message-room/components/options/OptionsDangerSection.tsx
+++ b/mirror-soul/src/features/message-room/components/options/OptionsDangerSection.tsx
@@ -1,9 +1,72 @@
 import React from 'react';
-import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { View, Text, StyleSheet, Pressable, Alert, Linking } from 'react-native';
 import { Feather, Ionicons } from '@expo/vector-icons';
 import { Colors, FontFamily, FontSize, FontWeight, Spacing } from '@/src/constants/theme';
+import { blockRoom } from '@/src/utils/blockList';
+import { SUPPORT_EMAIL } from '@/src/features/customer-center/constants/faqData';
+import { logger } from '@/src/utils/logger';
+import { ChatRoom } from '../../types';
 
-export function OptionsDangerSection() {
+interface OptionsDangerSectionProps {
+  room: ChatRoom;
+  /** 차단 완료 후 호출 (패널 닫기 + 대화방 나가기 등) */
+  onBlocked: () => void;
+}
+
+/**
+ * 실시간 통화가 있는 앱은 차단/신고 수단이 필수다 (App Store Guideline 1.2).
+ * 서버에 차단/신고 API가 아직 없으므로:
+ * - 차단: 로컬 차단 목록(blockList.ts)에 추가 — 이 기기에서는 다시 이 대화방에 들어갈 수 없음
+ * - 신고: 이메일로 고객센터에 신고 내용 전송 (customer-center의 SUPPORT_EMAIL 재사용)
+ */
+export function OptionsDangerSection({ room, onBlocked }: OptionsDangerSectionProps) {
+  const handleBlock = () => {
+    Alert.alert(
+      '차단하시겠습니까?',
+      `${room.name}님을 차단하면 더 이상 대화를 주고받을 수 없습니다.`,
+      [
+        { text: '취소', style: 'cancel' },
+        {
+          text: '차단',
+          style: 'destructive',
+          onPress: async () => {
+            await blockRoom(room.id);
+            onBlocked();
+          },
+        },
+      ]
+    );
+  };
+
+  const handleReport = async () => {
+    const subject = encodeURIComponent('[Mirror Soul] 사용자 신고');
+    const bodyTemplate = `아래 양식에 맞춰 신고 내용을 작성해 주시면 더욱 빠른 확인이 가능합니다.
+
+---
+■ 신고 대상: ${room.name} (대화방 ID: ${room.id})
+■ 신고 사유:
+(예: 부적절한 발언, 사기 의심, 불쾌한 대화 내용 등)
+■ 상세 내용:
+(여기에 자세한 신고 내용을 남겨주세요)
+---
+
+감사합니다.`;
+    const body = encodeURIComponent(bodyTemplate);
+    const url = `mailto:${SUPPORT_EMAIL}?subject=${subject}&body=${body}`;
+
+    try {
+      const canOpen = await Linking.canOpenURL(url);
+      if (canOpen) {
+        await Linking.openURL(url);
+      } else {
+        Alert.alert('메일 앱을 열 수 없습니다', `${SUPPORT_EMAIL} 으로 직접 신고해 주세요.`);
+      }
+    } catch (error) {
+      logger.error('OptionsDangerSection: failed to open report email', error);
+      Alert.alert('오류가 발생했습니다', `${SUPPORT_EMAIL} 으로 직접 신고해 주세요.`);
+    }
+  };
+
   return (
     <View style={[styles.menuSection, styles.dangerSection]}>
       <Text style={styles.sectionLabel}>DANGER ZONE</Text>
@@ -18,9 +81,19 @@ export function OptionsDangerSection() {
         </Pressable>
       </View>
 
+      {/* 신고하기 */}
+      <View style={styles.menuItemMarginSm}>
+        <Pressable style={styles.menuItem} onPress={handleReport}>
+          <View style={styles.menuItemLeft}>
+            <Feather name="flag" size={16} color={Colors.neutral.darkGray} />
+            <Text style={styles.dangerItemText}>신고하기</Text>
+          </View>
+        </Pressable>
+      </View>
+
       {/* 차단하기 */}
       <View style={styles.menuItemMarginSm}>
-        <Pressable style={styles.menuItem}>
+        <Pressable style={styles.menuItem} onPress={handleBlock}>
           <View style={styles.menuItemLeft}>
             <Ionicons name="ban-outline" size={16} color={Colors.neutral.darkGray} />
             <Text style={styles.dangerItemText}>차단하기</Text>

--- a/mirror-soul/src/utils/blockList.ts
+++ b/mirror-soul/src/utils/blockList.ts
@@ -1,0 +1,40 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { logger } from './logger';
+
+const STORAGE_KEY = 'mirror-soul:blocked-room-ids';
+
+/**
+ * 클라이언트 사이드 임시 차단 목록.
+ *
+ * 서버에 차단 API가 아직 없어서(Track 3, 백엔드 협업 필요) 강제력은 없지만,
+ * 최소한 이 기기에서는 차단한 대화방이 다시 보이지 않도록 로컬에 저장한다.
+ * 실제 차단 API가 생기면 이 유틸은 그 API 호출로 교체하거나 병행해야 한다.
+ */
+
+const readBlockedIds = async (): Promise<string[]> => {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    logger.error('blockList: failed to read blocked ids', error);
+    return [];
+  }
+};
+
+export const isRoomBlocked = async (roomId: string): Promise<boolean> => {
+  const blocked = await readBlockedIds();
+  return blocked.includes(roomId);
+};
+
+export const blockRoom = async (roomId: string): Promise<void> => {
+  const blocked = await readBlockedIds();
+  if (blocked.includes(roomId)) return;
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify([...blocked, roomId]));
+};
+
+export const unblockRoom = async (roomId: string): Promise<void> => {
+  const blocked = await readBlockedIds();
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(blocked.filter((id) => id !== roomId)));
+};


### PR DESCRIPTION
A real-time-call dating app is required to have working block/report (Apple App Store Guideline 1.2). Neither existed: the "차단하기" button in message-room's options panel had no onPress handler at all, and there was no report feature anywhere in the app.

No backend block/report API exists yet (Track 3 in the MVP readiness plan), so this implements the strongest thing possible client-side:

- src/utils/blockList.ts: AsyncStorage-backed local blocklist keyed by chat room id. No server enforcement — the blocked person isn't prevented from contacting this user again from their side — but this device will no longer show that conversation.
- OptionsDangerSection's block button now confirms via Alert, adds to the blocklist, then closes the panel and navigates out of the room.
- app/message-room/[id].tsx checks the blocklist before rendering and shows "차단한 대화 상대입니다" instead of the conversation.
- Added a "신고하기" (report) menu item that opens a pre-filled email to the existing customer-center SUPPORT_EMAIL, matching the pattern already used by EmailContactButton.tsx.

Deliberately scoped to message-room only: match/discovery screens use separate mock data without a real user-id scheme wired up yet, so retrofitting blocklist filtering there would be working against data that's going away once the real backend integration lands. Real server-side enforcement (so a blocked user can't re-contact at all) still needs the Track 3 backend work.

## 💡 작업 동기 및 목적
- 이 PR이 왜 필요한가요? (어떤 기능 추가/버그 수정인지 설명)
- 연관된 이슈 번호가 있다면 적어주세요. (예: Close #1)

## 📝 변경 사항
- 이 PR에서 핵심적으로 변경된 부분을 요약해주세요.
  - [x] 예: `LoginPage.tsx`에 SNS 로그인 버튼 추가
  - [x] 예: 라우팅 구조 변경 및 리다이렉트 처리 로직 버그 수정

## 📸 스크린샷 (선택)
- UI 변경이 있다면 전/후 사진이나 구현된 화면을 첨부해주세요. (없으면 지우셔도 무방합니다)

## 🧐 리뷰 포인트 / 기타 특이사항
- 특별히 고민했던 로직이나, 나중에 다시 보거나 리팩토링할 필요가 있는 부분이 있나요?
  - (예시) *카카오 로그인 리다이렉트 로직이 아직 매끄럽지 않아서 임시로 setTimeout 처리를 해두었습니다.*
