### PR TITLE
feat(mvp): label call history as AI twin conversations

### DIFF
--- a/mirror-soul/src/components/home/history/detail/CallDetailHeader.tsx
+++ b/mirror-soul/src/components/home/history/detail/CallDetailHeader.tsx
@@ -53,7 +53,7 @@ export default function CallDetailHeader({
 
         {/* 텍스트 정보 */}
         <View style={styles.textInfo}>
-          <Text style={styles.nameText}>{name}</Text>
+          <Text style={styles.nameText}>{name}의 AI 트윈</Text>
           <View style={styles.subRow}>
             <Text style={styles.consistencyText}>유사도 {consistencyPercent}%</Text>
             <View style={styles.dot} />


### PR DESCRIPTION
Investigated all call-related screens for AI-twin disclosure gaps beyond CallHeader.tsx's existing "AI 트윈과 대화 중"/"AI 트윈에게 연결 중..." status text (already adequate — covers the live in-call state).

Found the gap in CallDetailHeader.tsx (call history detail screen, app/call-detail.tsx): it showed just the bare person's name with no indication these are AI twin conversations, not live calls with that person. Changed the header title from "{name}" to "{name}의 AI 트윈".

Note on scope: app/ai-call.tsx (the only currently-wired call screen) is actually for calling *your own* twin for self-reflection (see its entry-path comment: Grow tab → interview card), not the call-another-user's-twin flow described in the product concept — that flow's UI hooks exist (CallDetailHeader's onCallPress, callService's /calls/clones/{cloneUserUuid} route shape) but aren't wired to any screen yet. This disclosure fix applies regardless of which flow ends up calling it.

## 💡 작업 동기 및 목적
- 이 PR이 왜 필요한가요? (어떤 기능 추가/버그 수정인지 설명)
- 연관된 이슈 번호가 있다면 적어주세요. (예: Close #1)

## 📝 변경 사항
- 이 PR에서 핵심적으로 변경된 부분을 요약해주세요.
  - [x] 예: `LoginPage.tsx`에 SNS 로그인 버튼 추가
  - [x] 예: 라우팅 구조 변경 및 리다이렉트 처리 로직 버그 수정

## 📸 스크린샷 (선택)
- UI 변경이 있다면 전/후 사진이나 구현된 화면을 첨부해주세요. (없으면 지우셔도 무방합니다)

## 🧐 리뷰 포인트 / 기타 특이사항
- 특별히 고민했던 로직이나, 나중에 다시 보거나 리팩토링할 필요가 있는 부분이 있나요?
  - (예시) *카카오 로그인 리다이렉트 로직이 아직 매끄럽지 않아서 임시로 setTimeout 처리를 해두었습니다.*
