### PR TITLE
feat(profile): wire my-page screens to real backend API

### DIFF
--- a/mirror-soul/src/features/account/AccountDeleteScreen.tsx
+++ b/mirror-soul/src/features/account/AccountDeleteScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, StyleSheet } from 'react-native';
+import { Alert, View, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
 import { useThemeColors } from '@/src/hooks/useThemeColors';
 import { Header } from '@/src/components/common/Header';
 import { ScreenLayout } from '@/src/components/common/ScreenLayout';
@@ -7,9 +8,15 @@ import { ScreenLayout } from '@/src/components/common/ScreenLayout';
 import { DeleteWarningSection } from './components/DeleteWarningSection';
 import { DeleteConsentSection } from './components/DeleteConsentSection';
 import { DeleteConfirmBottomSheet } from './components/DeleteConfirmBottomSheet';
+import { deleteAccount } from '@/src/services/profileService';
+import { logout as logoutApi } from '@/src/services/authService';
+import { useAuthStore } from '@/src/store/useAuthStore';
+import { getErrorDisplayMessage } from '@/src/utils/apiErrorCode';
+import { logger } from '@/src/utils/logger';
 
 export const AccountDeleteScreen = () => {
   const { colors } = useThemeColors();
+  const router = useRouter();
   const [isConsentChecked, setIsConsentChecked] = useState(false);
   const [isConfirmSheetOpen, setIsConfirmSheetOpen] = useState(false);
 
@@ -22,10 +29,22 @@ export const AccountDeleteScreen = () => {
 
   const handleCloseConfirm = () => setIsConfirmSheetOpen(false);
 
-  const performDeleteAccount = () => {
-    console.log('Soft Delete API 호출 및 로그아웃 처리');
-    setIsConfirmSheetOpen(false);
-    // TODO: useAuthStore().logout(), Delete API 호출 등
+  const performDeleteAccount = async () => {
+    try {
+      await deleteAccount();
+      try {
+        await logoutApi();
+      } catch (error) {
+        // 탈퇴는 이미 성공했으므로 서버 세션 정리 실패는 무시하고 로컬 로그아웃은 계속 진행
+        logger.error('AccountDeleteScreen: /auth/logout after delete failed', error);
+      }
+      await useAuthStore.getState().logout();
+      setIsConfirmSheetOpen(false);
+      router.replace('/');
+    } catch (error) {
+      setIsConfirmSheetOpen(false);
+      Alert.alert('회원 탈퇴 실패', getErrorDisplayMessage(error, '회원 탈퇴에 실패했습니다. 잠시 후 다시 시도해주세요.'));
+    }
   };
 
   return (

--- a/mirror-soul/src/features/account/AccountSettingsScreen.tsx
+++ b/mirror-soul/src/features/account/AccountSettingsScreen.tsx
@@ -8,6 +8,9 @@ import Constants from 'expo-constants';
 import { NicknameEditModal } from './components/NicknameEditModal';
 import { LogoutBottomSheet } from './components/LogoutBottomSheet';
 import { useAccountStore } from '@/src/store/useAccountStore';
+import { useAuthStore } from '@/src/store/useAuthStore';
+import { logout as logoutApi } from '@/src/services/authService';
+import { logger } from '@/src/utils/logger';
 import { useThemeColors } from '@/src/hooks/useThemeColors';
 import { Header } from '@/src/components/common/Header';
 import { ScreenLayout } from '@/src/components/common/ScreenLayout';
@@ -35,10 +38,16 @@ export const AccountSettingsScreen = () => {
     setIsLogoutSheetOpen(false);
   };
 
-  const performLogout = () => {
-    console.log('로그아웃 처리');
+  const performLogout = async () => {
+    try {
+      await logoutApi();
+    } catch (error) {
+      // 서버 세션 정리가 실패해도 로컬 로그아웃(토큰 삭제)은 계속 진행
+      logger.error('AccountSettingsScreen: /auth/logout failed', error);
+    }
+    await useAuthStore.getState().logout();
     setIsLogoutSheetOpen(false);
-    // TODO: useAuthStore().logout() 등 실제 로그아웃 로직
+    router.replace('/');
   };
 
   const handleWithdraw = () => {

--- a/mirror-soul/src/features/account/components/NicknameEditModal.tsx
+++ b/mirror-soul/src/features/account/components/NicknameEditModal.tsx
@@ -18,6 +18,8 @@ import { useForm, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { useAccountStore } from '@/src/store/useAccountStore';
+import { modifyNickname } from '@/src/services/profileService';
+import { getErrorDisplayMessage } from '@/src/utils/apiErrorCode';
 
 const nicknameSchema = z.object({
   nickname: z
@@ -43,6 +45,7 @@ export const NicknameEditModal = ({ isOpen, onClose }: NicknameEditModalProps) =
     control,
     handleSubmit,
     reset,
+    setError,
     formState: { errors, isSubmitting },
   } = useForm<NicknameFormData>({
     resolver: zodResolver(nicknameSchema),
@@ -57,9 +60,13 @@ export const NicknameEditModal = ({ isOpen, onClose }: NicknameEditModalProps) =
   }, [isOpen, nickname, reset]);
 
   const onSubmit = async (data: NicknameFormData) => {
-    await new Promise((resolve) => setTimeout(resolve, 800)); // API delay mock
-    setNickname(data.nickname);
-    onClose();
+    try {
+      await modifyNickname(data.nickname);
+      setNickname(data.nickname);
+      onClose();
+    } catch (error) {
+      setError('nickname', { message: getErrorDisplayMessage(error, '닉네임 변경에 실패했습니다.') });
+    }
   };
 
   return (

--- a/mirror-soul/src/features/notification/hooks/useNotificationSettings.ts
+++ b/mirror-soul/src/features/notification/hooks/useNotificationSettings.ts
@@ -1,17 +1,23 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useNotificationStore } from '../../../store/useNotificationStore';
 
 /**
  * 알림 설정 훅
  *
  * 컴포넌트는 이 훅만 사용하여 스토어 구조와 디커플링을 유지합니다.
- * 추후 API 연동 시 이 훅 내부에서만 수정하면 됩니다.
+ * timeLimitAlert는 GET/PATCH /my-page/alarm과 동기화된다 (eventAlert는 백엔드에
+ * 대응 개념이 없어 로컬 전용으로 유지).
  */
 export const useNotificationSettings = () => {
   const timeLimitAlert = useNotificationStore((s) => s.timeLimitAlert);
   const eventAlert = useNotificationStore((s) => s.eventAlert);
   const toggleTimeLimitAlert = useNotificationStore((s) => s.toggleTimeLimitAlert);
   const toggleEventAlert = useNotificationStore((s) => s.toggleEventAlert);
+  const fetchAlarmSetting = useNotificationStore((s) => s.fetchAlarmSetting);
+
+  useEffect(() => {
+    fetchAlarmSetting();
+  }, [fetchAlarmSetting]);
 
   const handleToggleTimeLimit = useCallback(() => {
     toggleTimeLimitAlert();

--- a/mirror-soul/src/features/profile-settings/ProfileSettingsScreen.tsx
+++ b/mirror-soul/src/features/profile-settings/ProfileSettingsScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -9,11 +9,17 @@ import { Header } from '@/src/components/common/Header';
 import { ScreenLayout } from '@/src/components/common/ScreenLayout';
 import { useProfileSections } from '../profile/constants/profileMenu';
 import { Spacing } from '@/src/constants/theme';
+import { useCallTimeStore } from '@/src/store/useCallTimeStore';
 
 
 export const ProfileSettingsScreen = () => {
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const profileSections = useProfileSections();
+  const fetchRemainingTime = useCallTimeStore((state) => state.fetchRemainingTime);
+
+  useEffect(() => {
+    fetchRemainingTime();
+  }, [fetchRemainingTime]);
 
   const handleOpenSheet = useCallback(() => setIsSheetOpen(true), []);
   const handleCloseSheet = useCallback(() => setIsSheetOpen(false), []);

--- a/mirror-soul/src/features/profile/ProfileScreen.tsx
+++ b/mirror-soul/src/features/profile/ProfileScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
 
@@ -34,9 +34,15 @@ const MOCK_PROFILE: ProfileViewData = {
 
 export const ProfileScreen = () => {
   const router = useRouter();
-  const { nickname } = useAccountStore();
+  const { nickname, fetchProfile } = useAccountStore();
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
+  useEffect(() => {
+    fetchProfile();
+  }, [fetchProfile]);
+
+  // 백엔드 GET /my-page는 name/email만 제공한다. age/mbti/twinSimilarity 등
+  // 나머지 필드는 대응하는 API가 없어 당분간 mock을 유지한다 (feat/134-api 스코프 밖).
   const profile: ProfileViewData = {
     ...MOCK_PROFILE,
     name: nickname || MOCK_PROFILE.name,

--- a/mirror-soul/src/features/profile/components/TimeRefillBottomSheet.tsx
+++ b/mirror-soul/src/features/profile/components/TimeRefillBottomSheet.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {FontFamily, FontSize, FontWeight, Spacing} from '@/src/constants/theme';
 
-import { View, Text, StyleSheet } from 'react-native';
+import { Alert, View, Text, StyleSheet } from 'react-native';
 import { BottomSheet } from '../../../components/common/BottomSheet/BottomSheet';
-import { TIME_REFILL_OPTIONS } from '../constants/timeRefillOptions';
+import { TIME_REFILL_OPTIONS, TimeRefillOptionData } from '../constants/timeRefillOptions';
 import { TimeRefillOption } from './TimeRefillOption';
 import { useThemeColors } from '@/src/hooks/useThemeColors';
 import { useCallTimeStore, formatCallTime } from '@/src/store/useCallTimeStore';
+import { buyTime } from '@/src/services/profileService';
+import { getErrorDisplayMessage } from '@/src/utils/apiErrorCode';
 
 interface TimeRefillBottomSheetProps {
   isOpen: boolean;
@@ -16,6 +18,24 @@ interface TimeRefillBottomSheetProps {
 export const TimeRefillBottomSheet = ({ isOpen, onClose }: TimeRefillBottomSheetProps) => {
   const { colors } = useThemeColors();
   const remainingSeconds = useCallTimeStore((state) => state.remainingSeconds);
+  const setRemainingSeconds = useCallTimeStore((state) => state.setRemainingSeconds);
+  const [purchasingId, setPurchasingId] = useState<string | null>(null);
+
+  const handleSelectOption = async (option: TimeRefillOptionData) => {
+    if (purchasingId) return;
+    setPurchasingId(option.id);
+    try {
+      const response = await buyTime(option.seconds);
+      if (response.isSuccess) {
+        setRemainingSeconds(response.result.remainingTalkTime);
+        onClose();
+      }
+    } catch (error) {
+      Alert.alert('시간 충전 실패', getErrorDisplayMessage(error, '시간 충전에 실패했습니다. 잠시 후 다시 시도해주세요.'));
+    } finally {
+      setPurchasingId(null);
+    }
+  };
 
   return (
     <BottomSheet isOpen={isOpen} onClose={onClose} height={580}>
@@ -32,14 +52,11 @@ export const TimeRefillBottomSheet = ({ isOpen, onClose }: TimeRefillBottomSheet
         {/* Options */}
         <View style={styles.optionsContainer}>
           {TIME_REFILL_OPTIONS.map((option, index) => (
-            <TimeRefillOption 
-              key={option.id} 
-              option={option} 
+            <TimeRefillOption
+              key={option.id}
+              option={option}
               delay={index * 100} // Staggered entrance
-              onPress={() => {
-                // handle purchase logic
-                console.log('Selected:', option.id);
-              }}
+              onPress={() => handleSelectOption(option)}
             />
           ))}
         </View>

--- a/mirror-soul/src/features/profile/constants/timeRefillOptions.ts
+++ b/mirror-soul/src/features/profile/constants/timeRefillOptions.ts
@@ -3,6 +3,8 @@ export interface TimeRefillOptionData {
   addedTime: string;
   durationLabel: string;
   price: string;
+  /** 백엔드 POST /my-page/buy-time에 전달할 초 단위 값 */
+  seconds: number;
   badge?: {
     text: string;
     icon?: string;
@@ -17,6 +19,7 @@ export const TIME_REFILL_OPTIONS: TimeRefillOptionData[] = [
     addedTime: '+ 30분',
     durationLabel: '30분 동안 이야기 나누기',
     price: '₩4,900',
+    seconds: 30 * 60,
     styleType: 'default',
   },
   {
@@ -24,6 +27,7 @@ export const TIME_REFILL_OPTIONS: TimeRefillOptionData[] = [
     addedTime: '+ 2시간',
     durationLabel: '2시간 동안 이야기 나누기',
     price: '₩14,900',
+    seconds: 2 * 60 * 60,
     badge: {
       text: '인기',
       icon: '👑', // This could also be a vector icon if needed
@@ -36,6 +40,7 @@ export const TIME_REFILL_OPTIONS: TimeRefillOptionData[] = [
     addedTime: '+ 10시간',
     durationLabel: '10시간 가득 채우기',
     price: '₩59,000',
+    seconds: 10 * 60 * 60,
     badge: {
       text: '가장 경제적',
       type: 'best',

--- a/mirror-soul/src/features/voice-audio/hooks/useVoiceAudioSettings.ts
+++ b/mirror-soul/src/features/voice-audio/hooks/useVoiceAudioSettings.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { SpeedOption, useVoiceAudioStore } from '../../../store/useVoiceAudioStore';
 
 /**
@@ -9,13 +9,18 @@ import { SpeedOption, useVoiceAudioStore } from '../../../store/useVoiceAudioSto
  */
 export const useVoiceAudioSettings = () => {
   const speechSpeed = useVoiceAudioStore((s) => s.speechSpeed);
-  const setSpeechSpeed = useVoiceAudioStore((s) => s.setSpeechSpeed);
+  const fetchAudioSettings = useVoiceAudioStore((s) => s.fetchAudioSettings);
+  const syncSpeechSpeed = useVoiceAudioStore((s) => s.syncSpeechSpeed);
+
+  useEffect(() => {
+    fetchAudioSettings();
+  }, [fetchAudioSettings]);
 
   const handleSpeedChange = useCallback(
     (speed: SpeedOption) => {
-      setSpeechSpeed(speed);
+      syncSpeechSpeed(speed);
     },
-    [setSpeechSpeed]
+    [syncSpeechSpeed]
   );
 
   return {

--- a/mirror-soul/src/services/profileService.ts
+++ b/mirror-soul/src/services/profileService.ts
@@ -1,0 +1,151 @@
+import apiClient from './apiClient';
+import {
+  AccountInfoResponse,
+  AlarmSettingRequest,
+  AlarmSettingResponse,
+  AudioSettingsRequest,
+  AudioSettingsResponse,
+  BuyTimeRequest,
+  DeleteAccountResponse,
+  ModifyNicknameRequest,
+  ModifyNicknameResponse,
+  MyProfileResponse,
+  TimeStatusResponse,
+} from '../types/api/profile';
+import { logger } from '../utils/logger';
+
+/**
+ * 마이페이지(Profile) 도메인 API 서비스 (SoC)
+ */
+
+/** 마이페이지 진입 - 이름/이메일 조회 */
+export const getMyProfile = async (): Promise<MyProfileResponse> => {
+  logger.debug('getMyProfile');
+  try {
+    const response = await apiClient.get<MyProfileResponse>('/my-page');
+    logger.info('getMyProfile SUCCESS:', response.data);
+    return response.data;
+  } catch (error: unknown) {
+    logger.error('getMyProfile ERROR:', { message: error instanceof Error ? error.message : String(error) });
+    throw error;
+  }
+};
+
+/** 나의 남은 대화 시간 조회 */
+export const getMyTime = async (): Promise<TimeStatusResponse> => {
+  logger.debug('getMyTime');
+  try {
+    const response = await apiClient.get<TimeStatusResponse>('/my-page/buy-time');
+    logger.info('getMyTime SUCCESS:', response.data);
+    return response.data;
+  } catch (error: unknown) {
+    logger.error('getMyTime ERROR:', { message: error instanceof Error ? error.message : String(error) });
+    throw error;
+  }
+};
+
+/** 대화 시간 채우기 (초 단위) */
+export const buyTime = async (seconds: number): Promise<TimeStatusResponse> => {
+  logger.debug('buyTime:', { seconds });
+  const body: BuyTimeRequest = { buyTime: seconds };
+  try {
+    const response = await apiClient.post<TimeStatusResponse>('/my-page/buy-time', body);
+    logger.info('buyTime SUCCESS:', response.data);
+    return response.data;
+  } catch (error: unknown) {
+    logger.error('buyTime ERROR:', { message: error instanceof Error ? error.message : String(error) });
+    throw error;
+  }
+};
+
+/** 음성 및 오디오 설정 조회 */
+export const getAudioSettings = async (): Promise<AudioSettingsResponse> => {
+  logger.debug('getAudioSettings');
+  try {
+    const response = await apiClient.get<AudioSettingsResponse>('/my-page/audio-settings');
+    logger.info('getAudioSettings SUCCESS:', response.data);
+    return response.data;
+  } catch (error: unknown) {
+    logger.error('getAudioSettings ERROR:', { message: error instanceof Error ? error.message : String(error) });
+    throw error;
+  }
+};
+
+/** 음성 및 오디오 설정 수정 */
+export const updateAudioSettings = async (data: AudioSettingsRequest): Promise<AudioSettingsResponse> => {
+  logger.debug('updateAudioSettings:', data);
+  try {
+    const response = await apiClient.patch<AudioSettingsResponse>('/my-page/audio-settings', data);
+    logger.info('updateAudioSettings SUCCESS:', response.data);
+    return response.data;
+  } catch (error: unknown) {
+    logger.error('updateAudioSettings ERROR:', { message: error instanceof Error ? error.message : String(error) });
+    throw error;
+  }
+};
+
+/** 알림 설정 조회 */
+export const getAlarmSetting = async (): Promise<AlarmSettingResponse> => {
+  logger.debug('getAlarmSetting');
+  try {
+    const response = await apiClient.get<AlarmSettingResponse>('/my-page/alarm');
+    logger.info('getAlarmSetting SUCCESS:', response.data);
+    return response.data;
+  } catch (error: unknown) {
+    logger.error('getAlarmSetting ERROR:', { message: error instanceof Error ? error.message : String(error) });
+    throw error;
+  }
+};
+
+/** 알림 설정 수정 */
+export const modifyAlarmSetting = async (data: AlarmSettingRequest): Promise<AlarmSettingResponse> => {
+  logger.debug('modifyAlarmSetting:', data);
+  try {
+    const response = await apiClient.patch<AlarmSettingResponse>('/my-page/alarm', data);
+    logger.info('modifyAlarmSetting SUCCESS:', response.data);
+    return response.data;
+  } catch (error: unknown) {
+    logger.error('modifyAlarmSetting ERROR:', { message: error instanceof Error ? error.message : String(error) });
+    throw error;
+  }
+};
+
+/** 계정관리 조회 (닉네임) */
+export const getAccountInfo = async (): Promise<AccountInfoResponse> => {
+  logger.debug('getAccountInfo');
+  try {
+    const response = await apiClient.get<AccountInfoResponse>('/my-page/account');
+    logger.info('getAccountInfo SUCCESS:', response.data);
+    return response.data;
+  } catch (error: unknown) {
+    logger.error('getAccountInfo ERROR:', { message: error instanceof Error ? error.message : String(error) });
+    throw error;
+  }
+};
+
+/** 닉네임 변경 */
+export const modifyNickname = async (nickname: string): Promise<ModifyNicknameResponse> => {
+  logger.debug('modifyNickname:', { nickname });
+  const body: ModifyNicknameRequest = { nickname };
+  try {
+    const response = await apiClient.post<ModifyNicknameResponse>('/my-page/account', body);
+    logger.info('modifyNickname SUCCESS');
+    return response.data;
+  } catch (error: unknown) {
+    logger.error('modifyNickname ERROR:', { message: error instanceof Error ? error.message : String(error) });
+    throw error;
+  }
+};
+
+/** 회원 탈퇴 (Soft Delete) */
+export const deleteAccount = async (): Promise<DeleteAccountResponse> => {
+  logger.debug('deleteAccount');
+  try {
+    const response = await apiClient.delete<DeleteAccountResponse>('/my-page');
+    logger.info('deleteAccount SUCCESS');
+    return response.data;
+  } catch (error: unknown) {
+    logger.error('deleteAccount ERROR:', { message: error instanceof Error ? error.message : String(error) });
+    throw error;
+  }
+};

--- a/mirror-soul/src/store/useAccountStore.ts
+++ b/mirror-soul/src/store/useAccountStore.ts
@@ -1,11 +1,27 @@
 import { create } from 'zustand';
+import { getMyProfile } from '../services/profileService';
+import { logger } from '../utils/logger';
 
 interface AccountState {
   nickname: string;
+  email: string | null;
   setNickname: (name: string) => void;
+  /** GET /my-page 호출 후 이름/이메일을 반영. 실패 시 조용히 무시(기존 값 유지). */
+  fetchProfile: () => Promise<void>;
 }
 
 export const useAccountStore = create<AccountState>((set) => ({
   nickname: '김소울', // Initial MVP mock data
+  email: null,
   setNickname: (name) => set({ nickname: name }),
+  fetchProfile: async () => {
+    try {
+      const response = await getMyProfile();
+      if (response.isSuccess) {
+        set({ nickname: response.result.name, email: response.result.email });
+      }
+    } catch (error) {
+      logger.error('useAccountStore: fetchProfile failed', error);
+    }
+  },
 }));

--- a/mirror-soul/src/store/useCallTimeStore.ts
+++ b/mirror-soul/src/store/useCallTimeStore.ts
@@ -1,19 +1,30 @@
 import { create } from 'zustand';
+import { getMyTime } from '../services/profileService';
+import { logger } from '../utils/logger';
 
 interface CallTimeState {
-  /** 남은 통화 가능 시간 (초). 실제 결제/잔액 API 연동 전까지는 로컬 mock 값. */
+  /** 남은 통화 가능 시간 (초). GET /my-page/buy-time으로 조회된 서버 값의 로컬 캐시. */
   remainingSeconds: number;
   setRemainingSeconds: (seconds: number) => void;
   addSeconds: (seconds: number) => void;
+  /** GET /my-page/buy-time 호출 후 remainingSeconds를 서버 값으로 갱신. 실패 시 조용히 무시(기존 값 유지). */
+  fetchRemainingTime: () => Promise<void>;
 }
 
-// Initial MVP mock data: 02:30:00 (2시간 30분)
-const INITIAL_MOCK_SECONDS = 2 * 60 * 60 + 30 * 60;
-
 export const useCallTimeStore = create<CallTimeState>((set) => ({
-  remainingSeconds: INITIAL_MOCK_SECONDS,
+  remainingSeconds: 0,
   setRemainingSeconds: (seconds) => set({ remainingSeconds: seconds }),
   addSeconds: (seconds) => set((state) => ({ remainingSeconds: state.remainingSeconds + seconds })),
+  fetchRemainingTime: async () => {
+    try {
+      const response = await getMyTime();
+      if (response.isSuccess) {
+        set({ remainingSeconds: response.result.remainingTalkTime });
+      }
+    } catch (error) {
+      logger.error('useCallTimeStore: fetchRemainingTime failed', error);
+    }
+  },
 }));
 
 /** HH:MM:SS 형식으로 포맷. 실제 결제 연동 전까지 여러 화면에서 공통으로 사용. */

--- a/mirror-soul/src/store/useNotificationStore.ts
+++ b/mirror-soul/src/store/useNotificationStore.ts
@@ -1,6 +1,8 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import * as SecureStore from 'expo-secure-store';
+import { getAlarmSetting, modifyAlarmSetting } from '../services/profileService';
+import { logger } from '../utils/logger';
 
 /**
  * expo-secure-store 기반 Zustand persist 어댑터
@@ -27,32 +29,69 @@ const secureStorage = {
 };
 
 interface NotificationState {
-  /** 시간 소진 알림 (대화 가능 시간이 부족할 때) — 기본값: true */
+  /** 시간 소진 알림 (대화 가능 시간이 부족할 때) — 백엔드 lowTimeNotificationEnabled와 동기화 — 기본값: true */
   timeLimitAlert: boolean;
-  /** 혜택 및 이벤트 알림 (새로운 소식이나 혜택) — 기본값: false */
+  /** 혜택 및 이벤트 알림 (새로운 소식이나 혜택) — 백엔드에 대응 필드 없음, 로컬 전용 — 기본값: false */
   eventAlert: boolean;
+  /** 부재중 통화 알림. FE에 아직 토글 UI가 없는 숨김 필드 — 백엔드 missedCallNotificationEnabled가
+   *  PATCH 시 필수라서 GET으로 받은 값을 그대로 들고 있다가 함께 전송한다. */
+  missedCallNotificationEnabled: boolean;
 
   toggleTimeLimitAlert: () => void;
   toggleEventAlert: () => void;
+  /** GET /my-page/alarm 호출 후 스토어에 반영. 실패 시 조용히 무시(기존 값 유지). */
+  fetchAlarmSetting: () => Promise<void>;
 }
 
 /**
  * 알림 설정 스토어
  *
  * - SecureStore에 영속화: 앱 재시작 후에도 설정 유지
- * - 추후 백엔드 협의 후 PUT /notifications/settings API와 동기화 예정
- * - 참고: PUSH_NOTIFICATION_ARCHITECTURE.md
+ * - timeLimitAlert만 백엔드 PATCH /my-page/alarm과 동기화됨 (lowTimeNotificationEnabled).
+ *   eventAlert는 백엔드에 대응 개념이 없어 로컬 전용으로 남는다.
  */
 export const useNotificationStore = create<NotificationState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       timeLimitAlert: true,
       eventAlert: false,
+      missedCallNotificationEnabled: true,
 
-      toggleTimeLimitAlert: () =>
-        set((state) => ({ timeLimitAlert: !state.timeLimitAlert })),
+      toggleTimeLimitAlert: () => {
+        const nextValue = !get().timeLimitAlert;
+        set({ timeLimitAlert: nextValue });
+        modifyAlarmSetting({
+          lowTimeNotificationEnabled: nextValue,
+          missedCallNotificationEnabled: get().missedCallNotificationEnabled,
+        })
+          .then((response) => {
+            if (response.isSuccess) {
+              set({
+                timeLimitAlert: response.result.lowTimeNotificationEnabled,
+                missedCallNotificationEnabled: response.result.missedCallNotificationEnabled,
+              });
+            }
+          })
+          .catch((error) => {
+            logger.error('useNotificationStore: toggleTimeLimitAlert sync failed', error);
+            set({ timeLimitAlert: !nextValue });
+          });
+      },
       toggleEventAlert: () =>
         set((state) => ({ eventAlert: !state.eventAlert })),
+      fetchAlarmSetting: async () => {
+        try {
+          const response = await getAlarmSetting();
+          if (response.isSuccess) {
+            set({
+              timeLimitAlert: response.result.lowTimeNotificationEnabled,
+              missedCallNotificationEnabled: response.result.missedCallNotificationEnabled,
+            });
+          }
+        } catch (error) {
+          logger.error('useNotificationStore: fetchAlarmSetting failed', error);
+        }
+      },
     }),
     {
       name: 'notification-settings',

--- a/mirror-soul/src/store/useVoiceAudioStore.ts
+++ b/mirror-soul/src/store/useVoiceAudioStore.ts
@@ -1,12 +1,38 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import * as SecureStore from 'expo-secure-store';
+import { getAudioSettings, updateAudioSettings } from '../services/profileService';
+import { SpeechSpeed } from '../types/api/profile';
+import { logger } from '../utils/logger';
 
 export type SpeedOption = 'slow' | 'normal' | 'fast';
 
+const SPEED_OPTION_BY_SPEECH_SPEED: Record<SpeechSpeed, SpeedOption> = {
+  SLOW: 'slow',
+  NORMAL: 'normal',
+  FAST: 'fast',
+};
+
+const SPEECH_SPEED_BY_SPEED_OPTION: Record<SpeedOption, SpeechSpeed> = {
+  slow: 'SLOW',
+  normal: 'NORMAL',
+  fast: 'FAST',
+};
+
+const toSpeedOption = (speed: SpeechSpeed): SpeedOption => SPEED_OPTION_BY_SPEECH_SPEED[speed];
+
+const toSpeechSpeed = (speed: SpeedOption): SpeechSpeed => SPEECH_SPEED_BY_SPEED_OPTION[speed];
+
 interface VoiceAudioState {
   speechSpeed: SpeedOption;
+  /** 백엔드 audio-settings API가 요구하지만 FE에 아직 볼륨 조절 UI가 없는 숨김 필드.
+   *  GET으로 받은 값을 그대로 들고 있다가 PATCH 시 함께 전송한다. */
+  opponentVoiceVolume: number;
   setSpeechSpeed: (speed: SpeedOption) => void;
+  /** GET /my-page/audio-settings 호출 후 스토어에 반영. 실패 시 조용히 무시(기존 값 유지). */
+  fetchAudioSettings: () => Promise<void>;
+  /** speechSpeed 변경을 PATCH /my-page/audio-settings로 서버에 반영 (opponentVoiceVolume은 최신 값 그대로 전송) */
+  syncSpeechSpeed: (speed: SpeedOption) => Promise<void>;
 }
 
 /**
@@ -42,9 +68,42 @@ const secureStorage = {
  */
 export const useVoiceAudioStore = create<VoiceAudioState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       speechSpeed: 'normal',
+      opponentVoiceVolume: 50,
       setSpeechSpeed: (speed) => set({ speechSpeed: speed }),
+      fetchAudioSettings: async () => {
+        try {
+          const response = await getAudioSettings();
+          if (response.isSuccess) {
+            set({
+              speechSpeed: toSpeedOption(response.result.opponentSpeechSpeed),
+              opponentVoiceVolume: response.result.opponentVoiceVolume,
+            });
+          }
+        } catch (error) {
+          logger.error('useVoiceAudioStore: fetchAudioSettings failed', error);
+        }
+      },
+      syncSpeechSpeed: async (speed) => {
+        const previousSpeed = get().speechSpeed;
+        set({ speechSpeed: speed });
+        try {
+          const response = await updateAudioSettings({
+            opponentVoiceVolume: get().opponentVoiceVolume,
+            opponentSpeechSpeed: toSpeechSpeed(speed),
+          });
+          if (response.isSuccess) {
+            set({
+              speechSpeed: toSpeedOption(response.result.opponentSpeechSpeed),
+              opponentVoiceVolume: response.result.opponentVoiceVolume,
+            });
+          }
+        } catch (error) {
+          logger.error('useVoiceAudioStore: syncSpeechSpeed failed', error);
+          set({ speechSpeed: previousSpeed });
+        }
+      },
     }),
     {
       name: 'voice-audio-settings',

--- a/mirror-soul/src/types/api/profile.ts
+++ b/mirror-soul/src/types/api/profile.ts
@@ -1,0 +1,90 @@
+import { ApiResponse } from './common';
+
+/**
+ * 마이페이지(Profile) 도메인 API 타입 정의
+ * 백엔드 ProfileController(`/my-page`) 기준
+ */
+
+export type SpeechSpeed = 'SLOW' | 'NORMAL' | 'FAST';
+
+// ─────────────────────────────────────────────
+// GET /my-page
+// ─────────────────────────────────────────────
+export interface MyProfileResult {
+  name: string;
+  email: string;
+}
+
+export type MyProfileResponse = ApiResponse<MyProfileResult>;
+
+// ─────────────────────────────────────────────
+// GET /my-page/buy-time
+// POST /my-page/buy-time
+// ─────────────────────────────────────────────
+export interface TimeStatusResult {
+  remainingTalkTime: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+}
+
+export type TimeStatusResponse = ApiResponse<TimeStatusResult>;
+
+export interface BuyTimeRequest {
+  buyTime: number;
+}
+
+// ─────────────────────────────────────────────
+// GET /my-page/audio-settings
+// PATCH /my-page/audio-settings
+// ─────────────────────────────────────────────
+export interface AudioSettingsResult {
+  opponentVoiceVolume: number;
+  opponentSpeechSpeed: SpeechSpeed;
+}
+
+export type AudioSettingsResponse = ApiResponse<AudioSettingsResult>;
+
+export interface AudioSettingsRequest {
+  opponentVoiceVolume: number;
+  opponentSpeechSpeed: SpeechSpeed;
+}
+
+// ─────────────────────────────────────────────
+// GET /my-page/alarm
+// PATCH /my-page/alarm
+// ─────────────────────────────────────────────
+export interface AlarmSettingResult {
+  missedCallNotificationEnabled: boolean;
+  lowTimeNotificationEnabled: boolean;
+}
+
+export type AlarmSettingResponse = ApiResponse<AlarmSettingResult>;
+
+export interface AlarmSettingRequest {
+  missedCallNotificationEnabled: boolean;
+  lowTimeNotificationEnabled: boolean;
+}
+
+// ─────────────────────────────────────────────
+// GET /my-page/account
+// ─────────────────────────────────────────────
+export interface AccountInfoResult {
+  name: string;
+}
+
+export type AccountInfoResponse = ApiResponse<AccountInfoResult>;
+
+// ─────────────────────────────────────────────
+// POST /my-page/account
+// ─────────────────────────────────────────────
+export interface ModifyNicknameRequest {
+  nickname: string;
+}
+
+export type ModifyNicknameResponse = ApiResponse<null>;
+
+// ─────────────────────────────────────────────
+// DELETE /my-page
+// ─────────────────────────────────────────────
+export type DeleteAccountResponse = ApiResponse<null>;

--- a/mirror-soul/src/utils/apiErrorCode.ts
+++ b/mirror-soul/src/utils/apiErrorCode.ts
@@ -1,0 +1,122 @@
+/**
+ * 백엔드(GeneralErrorCode) 및 apiClient 자체 합성 코드를 아우르는 공통 에러코드 유틸리티.
+ *
+ * 목적은 "번역"이 아니라 "코드 기반 동작 분기"다 — 백엔드가 이미 적절한 한글 메시지를
+ * `error.message`로 내려주므로, 대부분은 그 메시지를 그대로 보여주면 된다. 여기서는
+ * (a) 매직 스트링 방지를 위한 타입, (b) 화면별로 다른 UX가 필요한 코드만 예외적으로
+ * 오버라이드하는 메시지 매핑, (c) 카테고리 판별 헬퍼를 제공한다.
+ */
+
+/** 백엔드 GeneralErrorCode 47개 전수 (backend-schema.json errorCodes 기준) */
+export type BackendErrorCode =
+  | 'DUPLICATE_LOGINID'
+  | 'NOT_AGREED_TERM'
+  | 'EMAIL_CODE_ATTEMPT_EXCEEDED'
+  | 'MISSING_AUTH_INFO'
+  | 'INVALID_LOGIN'
+  | 'INVALID_TOKEN'
+  | 'TOKEN_EXPIRED'
+  | 'EMAIL_NOT_VERIFIED'
+  | 'FORBIDDEN'
+  | 'MISSING_PARAMETER'
+  | 'INVALID_PARAMETER'
+  | 'UNSUPPORTED_CONTENT_TYPE'
+  | 'API_NOT_FOUND'
+  | 'METHOD_NOT_ALLOWED'
+  | 'FILE_EMPTY'
+  | 'UNSUPPORTED_FILE_TYPE'
+  | 'FILE_TOO_LARGE'
+  | 'S3_UPLOAD_FAILED'
+  | 'S3_DELETE_FAILED'
+  | 'S3_CONNECTION_FAILED'
+  | 'INTERNAL_SERVER_ERROR'
+  | 'SERVICE_UNAVAILABLE'
+  | 'EXTERNAL_SERVICE_TIMEOUT'
+  | 'USER_NOT_FOUND'
+  | 'DUPLICATE_EMAIL'
+  | 'DUPLICATE_NICKNAME'
+  | 'REGION_NOT_FOUND'
+  | 'EMAIL_NOT_FOUND'
+  | 'EMAIL_CODE_NOT_REQUESTED'
+  | 'EMAIL_CODE_EXPIRED'
+  | 'EMAIL_CODE_MISMATCH'
+  | 'EMAIL_ALREADY_VERIFIED'
+  | 'EMAIL_SEND_FAILED'
+  | 'CLONE_NOT_FOUND'
+  | 'CALL_NOT_FOUND'
+  | 'CALL_ALREADY_ENDED'
+  | 'INSUFFICIENT_TALK_TIME'
+  | 'MEETING_REQUEST_NOT_FOUND'
+  | 'MEETING_REQUEST_ALREADY_PENDING'
+  | 'MEETING_REQUEST_ALREADY_PROCESSED'
+  | 'MEETING_CHAT_ALREADY_EXISTS'
+  | 'MEETING_INVALID_CALL'
+  | 'MEETING_SELF_REQUEST'
+  | 'MEETING_RECEIVER_INACTIVE'
+  | 'CHAT_ROOM_NOT_FOUND'
+  | 'CHAT_MESSAGE_NOT_FOUND'
+  | 'CHAT_ROOM_ACCESS_DENIED';
+
+/** apiClient.ts 응답 인터셉터가 전송 계층 실패에 대해 자체적으로 합성하는 코드 */
+export type ClientSyntheticErrorCode = 'AUTH_FAILED' | 'TIMEOUT' | 'NETWORK_ERROR' | 'UNKNOWN_ERROR';
+
+export type ApiErrorCode = BackendErrorCode | ClientSyntheticErrorCode;
+
+interface ApiErrorLike {
+  code?: string;
+  message?: string;
+}
+
+const DEFAULT_FALLBACK_MESSAGE = '알 수 없는 오류가 발생했습니다.';
+
+/**
+ * 코드별로 백엔드 메시지 대신 FE에서 보여주고 싶은 문구가 있을 때만 등록한다.
+ * 등록되지 않은 코드는 백엔드가 내려준 error.message를 그대로 사용한다.
+ */
+const CODE_MESSAGE_OVERRIDES: Partial<Record<ApiErrorCode, string>> = {
+  TIMEOUT: '서버 응답이 지연되고 있습니다. 잠시 후 다시 시도해주세요.',
+  NETWORK_ERROR: '네트워크 연결을 확인해주세요.',
+};
+
+/** 에러 객체에서 code 필드를 안전하게 추출 */
+export const getErrorCode = (error: unknown): ApiErrorCode | undefined => {
+  if (error && typeof error === 'object' && 'code' in error) {
+    return (error as ApiErrorLike).code as ApiErrorCode | undefined;
+  }
+  return undefined;
+};
+
+/**
+ * 사용자에게 보여줄 에러 메시지를 결정한다.
+ * 우선순위: FE 오버라이드 메시지 → 백엔드가 보낸 error.message → fallback
+ */
+export const getErrorDisplayMessage = (error: unknown, fallback = DEFAULT_FALLBACK_MESSAGE): string => {
+  const code = getErrorCode(error);
+  if (code && CODE_MESSAGE_OVERRIDES[code]) {
+    return CODE_MESSAGE_OVERRIDES[code]!;
+  }
+  if (error && typeof error === 'object' && 'message' in error) {
+    const message = (error as ApiErrorLike).message;
+    if (typeof message === 'string' && message.length > 0) {
+      return message;
+    }
+  }
+  return fallback;
+};
+
+/** 중복/충돌류 에러 (닉네임, 이메일 등) — 화면에서 Alert 대신 폼 인라인 에러로 보여줄지 분기할 때 사용 */
+export const isConflictError = (error: unknown): boolean => {
+  const code = getErrorCode(error);
+  return code === 'DUPLICATE_NICKNAME' || code === 'DUPLICATE_EMAIL' || code === 'DUPLICATE_LOGINID';
+};
+
+/** 인증 만료/무효 에러 — 재로그인 유도가 필요한지 분기할 때 사용 */
+export const isAuthError = (error: unknown): boolean => {
+  const code = getErrorCode(error);
+  return (
+    code === 'INVALID_TOKEN' ||
+    code === 'TOKEN_EXPIRED' ||
+    code === 'MISSING_AUTH_INFO' ||
+    code === 'AUTH_FAILED'
+  );
+};


### PR DESCRIPTION
Connects the Profile/my-page domain (auth logout, nickname edit, account deletion, call-time balance/refill, audio speed, alarm settings) to the backend ProfileController, replacing console.log stubs and hardcoded mock values (e.g. fixed "02:30:00" balance, no-op account deletion).

Adds a shared API error-code utility (types/api/profile.ts, services/profileService.ts, utils/apiErrorCode.ts) so failures can be branched on the backend's structured GeneralErrorCode instead of only displaying a generic message — reused going forward for Chat/Meeting/ Evolve/PushDevice once those get their own service layers.

Notification settings only sync the "시간 소진 알림" toggle (lowTimeNotificationEnabled); "혜택 및 이벤트 알림" has no backend equivalent and stays local-only. Audio volume has no FE UI yet, so opponentVoiceVolume is carried as a hidden field to satisfy the backend's required PATCH payload.

## 💡 작업 동기 및 목적
- 이 PR이 왜 필요한가요? (어떤 기능 추가/버그 수정인지 설명)
- 연관된 이슈 번호가 있다면 적어주세요. (예: Close #1)

## 📝 변경 사항
- 이 PR에서 핵심적으로 변경된 부분을 요약해주세요.
  - [x] 예: `LoginPage.tsx`에 SNS 로그인 버튼 추가
  - [x] 예: 라우팅 구조 변경 및 리다이렉트 처리 로직 버그 수정

## 📸 스크린샷 (선택)
- UI 변경이 있다면 전/후 사진이나 구현된 화면을 첨부해주세요. (없으면 지우셔도 무방합니다)

## 🧐 리뷰 포인트 / 기타 특이사항
- 특별히 고민했던 로직이나, 나중에 다시 보거나 리팩토링할 필요가 있는 부분이 있나요?
  - (예시) *카카오 로그인 리다이렉트 로직이 아직 매끄럽지 않아서 임시로 setTimeout 처리를 해두었습니다.*
